### PR TITLE
Fix MultiMap.associations example

### DIFF
--- a/multi-map.md
+++ b/multi-map.md
@@ -252,7 +252,7 @@ var map = new MultiMap();
 map.set('john', {name: 'John', surname: 'Doe'});
 map.set('john', {name: 'John', surname: 'Watson'});
 
-var iterator = map.containers();
+var iterator = map.associations();
 
 iterator.next().value
 >>> [


### PR DESCRIPTION
The example of using #.associations instead uses #.contiainers, but does appear to correctly show the output of #.associations.