### PR TITLE
adds peek functionality to LRUCache and LRUMap

### DIFF
--- a/lru-cache.d.ts
+++ b/lru-cache.d.ts
@@ -18,6 +18,7 @@ export default class LRUCache<K, V> implements Iterable<[K, V]> {
   clear(): void;
   set(key: K, value: V): this;
   get(key: K): V | undefined;
+  peek(key: K): V | undefined;
   has(key: K): boolean;
   forEach(callback: (value: V, key: K, cache: this) => void, scope?: any): void;
   keys(): Iterator<K>;

--- a/lru-cache.js
+++ b/lru-cache.js
@@ -168,6 +168,22 @@ LRUCache.prototype.get = function(key) {
 };
 
 /**
+ * Method used to get the value attached to the given key. Does not modify
+ * the ordering of the underlying linked list.
+ *
+ * @param  {any} key   - Key.
+ * @return {any}
+ */
+LRUCache.prototype.peek = function(key) {
+    var pointer = this.items[key];
+
+    if (typeof pointer === 'undefined')
+        return;
+
+    return this.V[pointer];
+};
+
+/**
  * Method used to iterate over the cache's entries using a callback.
  *
  * @param  {function}  callback - Function to call for each item.

--- a/lru-map.d.ts
+++ b/lru-map.d.ts
@@ -18,6 +18,7 @@ export default class LRUMap<K, V> implements Iterable<[K, V]> {
   clear(): void;
   set(key: K, value: V): this;
   get(key: K): V | undefined;
+  peek(key: K): V | undefined;
   has(key: K): boolean;
   forEach(callback: (value: V, key: K, cache: this) => void, scope?: any): void;
   keys(): Iterator<K>;

--- a/lru-map.js
+++ b/lru-map.js
@@ -127,6 +127,21 @@ LRUMap.prototype.get = function(key) {
   return this.V[pointer];
 };
 
+/**
+ * Method used to get the value attached to the given key. Does not modify
+ * the ordering of the underlying linked list.
+ *
+ * @param  {any} key   - Key.
+ * @return {any}
+ */
+LRUMap.prototype.peek = function(key) {
+  var pointer = this.items.get(key);
+
+  if (typeof pointer === 'undefined')
+    return;
+
+  return this.V[pointer];
+};
 
 /**
  * Methods that can be reused as-is from LRUCache.

--- a/test/lru-cache.js
+++ b/test/lru-cache.js
@@ -53,6 +53,9 @@ function makeTests(Cache, name) {
       assert.strictEqual(cache.get('three'), 3);
       assert.deepEqual(Array.from(cache.entries()), [['three', 3], ['four', 4], ['two', 5]]);
 
+      assert.strictEqual(cache.peek('two'), 5);
+      assert.deepEqual(Array.from(cache.entries()), [['three', 3], ['four', 4], ['two', 5]]);
+
       if (name === 'LRUCache')
         assert.strictEqual(Object.keys(cache.items).length, 3);
       else


### PR DESCRIPTION
Under some circumstances, it's useful to be able to retrieve data from a LRU cache without affecting the cache ordering itself. 

This PR adds a `peek` method to both `LRUCache` and `LRUMap` that simply skips the `splayOnTop` step when retrieving data. 

The relevant test has also been modified to test that accessing an element not currently at the top does not modify the cache ordering