### PR TITLE
optional callback when setting a value in LRU classes

### DIFF
--- a/lru-cache.d.ts
+++ b/lru-cache.d.ts
@@ -17,7 +17,7 @@ export default class LRUCache<K, V> implements Iterable<[K, V]> {
   // Methods
   clear(): void;
   set(key: K, value: V): this;
-  setpop(key: K, value: V): {evicted: boolean, value: V, key: K};
+  setpop(key: K, value: V): {evicted: boolean, key: K, value: V};
   get(key: K): V | undefined;
   peek(key: K): V | undefined;
   has(key: K): boolean;

--- a/lru-cache.d.ts
+++ b/lru-cache.d.ts
@@ -16,7 +16,7 @@ export default class LRUCache<K, V> implements Iterable<[K, V]> {
 
   // Methods
   clear(): void;
-  set(key: K, value: V, callback: (v: V) => void): this;
+  set(key: K, value: V, callback: (oldKey: K, oldValue: V) => void): this;
   get(key: K): V | undefined;
   peek(key: K): V | undefined;
   has(key: K): boolean;

--- a/lru-cache.d.ts
+++ b/lru-cache.d.ts
@@ -16,7 +16,7 @@ export default class LRUCache<K, V> implements Iterable<[K, V]> {
 
   // Methods
   clear(): void;
-  set(key: K, value: V): this;
+  set(key: K, value: V, callback: (v: V) => void): this;
   get(key: K): V | undefined;
   peek(key: K): V | undefined;
   has(key: K): boolean;

--- a/lru-cache.d.ts
+++ b/lru-cache.d.ts
@@ -17,7 +17,7 @@ export default class LRUCache<K, V> implements Iterable<[K, V]> {
   // Methods
   clear(): void;
   set(key: K, value: V): this;
-  setWithCallback(key: K, value: V, callback: (oldValue: V, oldKey: K, overwriting: boolean) => void): this;
+  setpop(key: K, value: V): {evicted: boolean, value: V, key: K};
   get(key: K): V | undefined;
   peek(key: K): V | undefined;
   has(key: K): boolean;

--- a/lru-cache.d.ts
+++ b/lru-cache.d.ts
@@ -16,7 +16,8 @@ export default class LRUCache<K, V> implements Iterable<[K, V]> {
 
   // Methods
   clear(): void;
-  set(key: K, value: V, callback: (oldValue: V, oldKey: K) => void): this;
+  set(key: K, value: V): this;
+  setWithCallback(key: K, value: V, callback: (oldValue: V, oldKey: K, overwriting: boolean) => void): this;
   get(key: K): V | undefined;
   peek(key: K): V | undefined;
   has(key: K): boolean;

--- a/lru-cache.d.ts
+++ b/lru-cache.d.ts
@@ -16,7 +16,7 @@ export default class LRUCache<K, V> implements Iterable<[K, V]> {
 
   // Methods
   clear(): void;
-  set(key: K, value: V, callback: (oldKey: K, oldValue: V) => void): this;
+  set(key: K, value: V, callback: (oldValue: V, oldKey: K) => void): this;
   get(key: K): V | undefined;
   peek(key: K): V | undefined;
   has(key: K): boolean;

--- a/lru-cache.js
+++ b/lru-cache.js
@@ -128,7 +128,7 @@ LRUCache.prototype.set = function(key, value, callback) {
     pointer = this.tail;
     this.tail = this.backward[pointer];
     if (callback) {
-      callback(this.K[pointer], this.V[pointer]);
+      callback(this.V[pointer], this.K[pointer]);
     }
     delete this.items[this.K[pointer]];
   }

--- a/lru-cache.js
+++ b/lru-cache.js
@@ -128,7 +128,7 @@ LRUCache.prototype.set = function(key, value, callback) {
     pointer = this.tail;
     this.tail = this.backward[pointer];
     if (callback) {
-      callback(this.items[this.K[pointer]]);
+      callback(this.V[pointer]);
     }
     delete this.items[this.K[pointer]];
   }

--- a/lru-cache.js
+++ b/lru-cache.js
@@ -128,7 +128,7 @@ LRUCache.prototype.set = function(key, value, callback) {
     pointer = this.tail;
     this.tail = this.backward[pointer];
     if (callback) {
-      callback(this.V[pointer]);
+      callback(this.K[pointer], this.V[pointer]);
     }
     delete this.items[this.K[pointer]];
   }

--- a/lru-cache.js
+++ b/lru-cache.js
@@ -140,26 +140,27 @@ LRUCache.prototype.set = function(key, value) {
 };
 
 /**
- * Method used to set the value for the given key in the cache.
+ * Method used to set the value for the given key in the cache
  *
  * @param  {any} key   - Key.
  * @param  {any} value - Value.
- * @param  {function} callback - Callback function to be called
- * when evicting items from cache
- * @return {undefined}
+ * @return {{evicted: boolean, key: any, value: any}} An object containing the
+ * key and value of an item that was overwritten or evicted in the set
+ * operation, as well as a boolean indicating whether it was evicted due to
+ * limited capacity. Object is null if no values were evicted or overwritten in
+ * the set operation
  */
-LRUCache.prototype.setWithCallback = function(key, value, callback) {
-
+LRUCache.prototype.setpop = function(key, value) {
+  var oldValue = null;
+  var oldKey = null;
   // The key already exists, we just need to update the value and splay on top
   var pointer = this.items[key];
 
   if (typeof pointer !== 'undefined') {
     this.splayOnTop(pointer);
-    if (callback) {
-      callback(this.V[pointer], this.K[pointer], true);
-    }
+    oldValue = this.V[pointer];
     this.V[pointer] = value;
-    return;
+    return {evicted: false, key: key, value: oldValue};
   }
 
   // The cache is not yet full
@@ -171,9 +172,8 @@ LRUCache.prototype.setWithCallback = function(key, value, callback) {
   else {
     pointer = this.tail;
     this.tail = this.backward[pointer];
-    if (callback) {
-      callback(this.V[pointer], this.K[pointer], false);
-    }
+    oldValue = this.V[pointer];
+    oldKey = this.K[pointer];
     delete this.items[this.K[pointer]];
   }
 
@@ -186,6 +186,14 @@ LRUCache.prototype.setWithCallback = function(key, value, callback) {
   this.forward[pointer] = this.head;
   this.backward[this.head] = pointer;
   this.head = pointer;
+
+  // Return object if eviction took place, otherwise return null
+  if (oldKey) {
+    return {evicted: true, key: oldKey, value: oldValue};
+  }
+  else {
+    return null;
+  }
 };
 
 /**

--- a/lru-cache.js
+++ b/lru-cache.js
@@ -102,11 +102,9 @@ LRUCache.prototype.splayOnTop = function(pointer) {
  *
  * @param  {any} key   - Key.
  * @param  {any} value - Value.
- * @param  {function} callback - Callback function to be called
- * when evicting items from cache
  * @return {undefined}
  */
-LRUCache.prototype.set = function(key, value, callback) {
+LRUCache.prototype.set = function(key, value) {
 
   // The key already exists, we just need to update the value and splay on top
   var pointer = this.items[key];
@@ -127,8 +125,54 @@ LRUCache.prototype.set = function(key, value, callback) {
   else {
     pointer = this.tail;
     this.tail = this.backward[pointer];
+    delete this.items[this.K[pointer]];
+  }
+
+  // Storing key & value
+  this.items[key] = pointer;
+  this.K[pointer] = key;
+  this.V[pointer] = value;
+
+  // Moving the item at the front of the list
+  this.forward[pointer] = this.head;
+  this.backward[this.head] = pointer;
+  this.head = pointer;
+};
+
+/**
+ * Method used to set the value for the given key in the cache.
+ *
+ * @param  {any} key   - Key.
+ * @param  {any} value - Value.
+ * @param  {function} callback - Callback function to be called
+ * when evicting items from cache
+ * @return {undefined}
+ */
+LRUCache.prototype.setWithCallback = function(key, value, callback) {
+
+  // The key already exists, we just need to update the value and splay on top
+  var pointer = this.items[key];
+
+  if (typeof pointer !== 'undefined') {
+    this.splayOnTop(pointer);
     if (callback) {
-      callback(this.V[pointer], this.K[pointer]);
+      callback(this.V[pointer], this.K[pointer], true);
+    }
+    this.V[pointer] = value;
+    return;
+  }
+
+  // The cache is not yet full
+  if (this.size < this.capacity) {
+    pointer = this.size++;
+  }
+
+  // Cache is full, we need to drop the last value
+  else {
+    pointer = this.tail;
+    this.tail = this.backward[pointer];
+    if (callback) {
+      callback(this.V[pointer], this.K[pointer], false);
     }
     delete this.items[this.K[pointer]];
   }

--- a/lru-cache.js
+++ b/lru-cache.js
@@ -102,9 +102,11 @@ LRUCache.prototype.splayOnTop = function(pointer) {
  *
  * @param  {any} key   - Key.
  * @param  {any} value - Value.
+ * @param  {function} callback - Callback function to be called
+ * when evicting items from cache
  * @return {undefined}
  */
-LRUCache.prototype.set = function(key, value) {
+LRUCache.prototype.set = function(key, value, callback) {
 
   // The key already exists, we just need to update the value and splay on top
   var pointer = this.items[key];
@@ -125,6 +127,9 @@ LRUCache.prototype.set = function(key, value) {
   else {
     pointer = this.tail;
     this.tail = this.backward[pointer];
+    if (callback) {
+      callback(this.items[this.K[pointer]]);
+    }
     delete this.items[this.K[pointer]];
   }
 

--- a/lru-map.d.ts
+++ b/lru-map.d.ts
@@ -16,7 +16,7 @@ export default class LRUMap<K, V> implements Iterable<[K, V]> {
 
   // Methods
   clear(): void;
-  set(key: K, value: V, callback: (oldKey: K, oldValue: V) => void): this;
+  set(key: K, value: V, callback: (oldValue: V, oldKey: K) => void): this;
   get(key: K): V | undefined;
   peek(key: K): V | undefined;
   has(key: K): boolean;

--- a/lru-map.d.ts
+++ b/lru-map.d.ts
@@ -17,7 +17,7 @@ export default class LRUMap<K, V> implements Iterable<[K, V]> {
   // Methods
   clear(): void;
   set(key: K, value: V): this;
-  setWithCallback(key: K, value: V, callback: (oldValue: V, oldKey: K, overwriting: boolean) => void): this;
+  setpop(key: K, value: V): {evicted: boolean, value: V, key: K};
   get(key: K): V | undefined;
   peek(key: K): V | undefined;
   has(key: K): boolean;

--- a/lru-map.d.ts
+++ b/lru-map.d.ts
@@ -16,7 +16,7 @@ export default class LRUMap<K, V> implements Iterable<[K, V]> {
 
   // Methods
   clear(): void;
-  set(key: K, value: V): this;
+  set(key: K, value: V, callback: (v: V) => void): this;
   get(key: K): V | undefined;
   peek(key: K): V | undefined;
   has(key: K): boolean;

--- a/lru-map.d.ts
+++ b/lru-map.d.ts
@@ -16,7 +16,7 @@ export default class LRUMap<K, V> implements Iterable<[K, V]> {
 
   // Methods
   clear(): void;
-  set(key: K, value: V, callback: (v: V) => void): this;
+  set(key: K, value: V, callback: (oldKey: K, oldValue: V) => void): this;
   get(key: K): V | undefined;
   peek(key: K): V | undefined;
   has(key: K): boolean;

--- a/lru-map.d.ts
+++ b/lru-map.d.ts
@@ -16,7 +16,8 @@ export default class LRUMap<K, V> implements Iterable<[K, V]> {
 
   // Methods
   clear(): void;
-  set(key: K, value: V, callback: (oldValue: V, oldKey: K) => void): this;
+  set(key: K, value: V): this;
+  setWithCallback(key: K, value: V, callback: (oldValue: V, oldKey: K, overwriting: boolean) => void): this;
   get(key: K): V | undefined;
   peek(key: K): V | undefined;
   has(key: K): boolean;

--- a/lru-map.d.ts
+++ b/lru-map.d.ts
@@ -17,7 +17,7 @@ export default class LRUMap<K, V> implements Iterable<[K, V]> {
   // Methods
   clear(): void;
   set(key: K, value: V): this;
-  setpop(key: K, value: V): {evicted: boolean, value: V, key: K};
+  setpop(key: K, value: V): {evicted: boolean, key: K, value: V};
   get(key: K): V | undefined;
   peek(key: K): V | undefined;
   has(key: K): boolean;

--- a/lru-map.js
+++ b/lru-map.js
@@ -62,9 +62,11 @@ LRUMap.prototype.clear = function() {
  *
  * @param  {any} key   - Key.
  * @param  {any} value - Value.
+ * @param  {function} callback - Callback function to be called
+ * when evicting items from cache
  * @return {undefined}
  */
-LRUMap.prototype.set = function(key, value) {
+LRUMap.prototype.set = function(key, value, callback) {
 
   // The key already exists, we just need to update the value and splay on top
   var pointer = this.items.get(key);
@@ -85,6 +87,9 @@ LRUMap.prototype.set = function(key, value) {
   else {
     pointer = this.tail;
     this.tail = this.backward[pointer];
+    if (callback) {
+      callback(this.items[this.K[pointer]]);
+    }
     this.items.delete(this.K[pointer]);
   }
 

--- a/lru-map.js
+++ b/lru-map.js
@@ -88,7 +88,7 @@ LRUMap.prototype.set = function(key, value, callback) {
     pointer = this.tail;
     this.tail = this.backward[pointer];
     if (callback) {
-      callback(this.items[this.K[pointer]]);
+      callback(this.V[pointer]);
     }
     this.items.delete(this.K[pointer]);
   }

--- a/lru-map.js
+++ b/lru-map.js
@@ -101,26 +101,26 @@ LRUMap.prototype.set = function(key, value) {
 
 /**
  * Method used to set the value for the given key in the cache.
- * Runs a callback when a tile is overwritten or evicted
  *
  * @param  {any} key   - Key.
  * @param  {any} value - Value.
- * @param  {function} callback - Callback function to be called
- * when evicting or overwriting items from cache
- * @return {undefined}
+ * @return {{evicted: boolean, key: any, value: any}} An object containing the
+ * key and value of an item that was overwritten or evicted in the set
+ * operation, as well as a boolean indicating whether it was evicted due to
+ * limited capacity. Object is null if no values were evicted or overwritten in
+ * the set operation
  */
-LRUMap.prototype.setWithCallback = function(key, value, callback) {
-
+LRUMap.prototype.setpop = function(key, value) {
+  var oldValue = null;
+  var oldKey = null;
   // The key already exists, we just need to update the value and splay on top
   var pointer = this.items.get(key);
 
   if (typeof pointer !== 'undefined') {
     this.splayOnTop(pointer);
-    if (callback) {
-      callback(this.V[pointer], this.K[pointer], true);
-    }
+    oldValue = this.V[pointer];
     this.V[pointer] = value;
-    return;
+    return {evicted: false, key: key, value: oldValue};
   }
 
   // The cache is not yet full
@@ -132,9 +132,8 @@ LRUMap.prototype.setWithCallback = function(key, value, callback) {
   else {
     pointer = this.tail;
     this.tail = this.backward[pointer];
-    if (callback) {
-      callback(this.V[pointer], this.K[pointer], false);
-    }
+    oldValue = this.V[pointer];
+    oldKey = this.K[pointer];
     this.items.delete(this.K[pointer]);
   }
 
@@ -147,6 +146,14 @@ LRUMap.prototype.setWithCallback = function(key, value, callback) {
   this.forward[pointer] = this.head;
   this.backward[this.head] = pointer;
   this.head = pointer;
+
+  // Return object if eviction took place, otherwise return null
+  if (oldKey) {
+    return {evicted: true, key: oldKey, value: oldValue};
+  }
+  else {
+    return null;
+  }
 };
 
 /**

--- a/lru-map.js
+++ b/lru-map.js
@@ -88,7 +88,7 @@ LRUMap.prototype.set = function(key, value, callback) {
     pointer = this.tail;
     this.tail = this.backward[pointer];
     if (callback) {
-      callback(this.K[pointer], this.V[pointer]);
+      callback(this.V[pointer], this.K[pointer]);
     }
     this.items.delete(this.K[pointer]);
   }

--- a/lru-map.js
+++ b/lru-map.js
@@ -88,7 +88,7 @@ LRUMap.prototype.set = function(key, value, callback) {
     pointer = this.tail;
     this.tail = this.backward[pointer];
     if (callback) {
-      callback(this.V[pointer]);
+      callback(this.K[pointer], this.V[pointer]);
     }
     this.items.delete(this.K[pointer]);
   }

--- a/test/lru-cache.js
+++ b/test/lru-cache.js
@@ -129,10 +129,10 @@ function makeTests(Cache, name) {
           cache.set('one', 1);
           cache.set('two', 2);
           var popResult = cache.setpop('three', 3);
-          assert.equal(popResult, null)
+          assert.equal(popResult, null);
     });
 
-    it('should be possible to get a callback when items are overwritten from cache', function() {
+    it('should be possible to pop an overwritten value when items are overwritten from cache', function() {
       var cache = new Cache(3);
 
       cache.set('one', 1);

--- a/test/lru-cache.js
+++ b/test/lru-cache.js
@@ -120,7 +120,7 @@ function makeTests(Cache, name) {
 
       var evictedValue = 0;
       var evictedKey = '';
-      cache.set('four', 4, function(k, v) {
+      cache.set('four', 4, function(v, k) {
         evictedKey = k;
         evictedValue = v;
       });

--- a/test/lru-cache.js
+++ b/test/lru-cache.js
@@ -123,6 +123,15 @@ function makeTests(Cache, name) {
       assert.deepEqual(Array.from(cache.values()), [4, 3, 2]);
     });
 
+    it('should return null when setting an item does not overwrite or evict', function() {
+          var cache = new Cache(3);
+
+          cache.set('one', 1);
+          cache.set('two', 2);
+          var popResult = cache.setpop('three', 3);
+          assert.equal(popResult, null)
+    });
+
     it('should be possible to get a callback when items are overwritten from cache', function() {
       var cache = new Cache(3);
 

--- a/test/lru-cache.js
+++ b/test/lru-cache.js
@@ -120,14 +120,39 @@ function makeTests(Cache, name) {
 
       var evictedValue = 0;
       var evictedKey = '';
-      cache.set('four', 4, function(v, k) {
+      var isOverwritten = false;
+      cache.setWithCallback('four', 4, function(v, k, overwritten) {
         evictedKey = k;
         evictedValue = v;
+        isOverwritten = overwritten;
       });
 
       assert.deepEqual(Array.from(cache.values()), [4, 3, 2]);
       assert.equal(evictedKey, 'one');
       assert.equal(evictedValue, 1);
+      assert.equal(isOverwritten, false);
+    });
+
+    it('should be possible to get a callback when items are overwritten from cache', function() {
+      var cache = new Cache(3);
+
+      cache.set('one', 1);
+      cache.set('two', 2);
+      cache.set('three', 3);
+
+      var overwrittenValue = 0;
+      var overwrittenKey = '';
+      var isOverwritten = false;
+      cache.setWithCallback('three', 10, function(v, k, overwritten) {
+        overwrittenKey = k;
+        overwrittenValue = v;
+        isOverwritten = overwritten;
+      });
+
+      assert.deepEqual(Array.from(cache.values()), [10, 2, 1]);
+      assert.equal(overwrittenKey, 'three');
+      assert.equal(overwrittenValue, 3);
+      assert.equal(isOverwritten, true);
     });
 
     it('should work with capacity = 1.', function() {

--- a/test/lru-cache.js
+++ b/test/lru-cache.js
@@ -111,6 +111,22 @@ function makeTests(Cache, name) {
       assert.deepEqual(Array.from(cache.values()), [3, 2, 1]);
     });
 
+    it('should be possible to get a callback when items are evicted from cache', function() {
+      var cache = new Cache(3);
+
+      cache.set('one', 1);
+      cache.set('two', 2);
+      cache.set('three', 3);
+
+      var result = 0;
+      cache.set('four', 4, function(v) {
+        result = v;
+      });
+
+      assert.deepEqual(Array.from(cache.values()), [4, 3, 2]);
+      assert.equal(result, 1);
+    });
+
     it('should work with capacity = 1.', function() {
       var cache = new Cache(1);
 

--- a/test/lru-cache.js
+++ b/test/lru-cache.js
@@ -111,26 +111,16 @@ function makeTests(Cache, name) {
       assert.deepEqual(Array.from(cache.values()), [3, 2, 1]);
     });
 
-    it('should be possible to get a callback when items are evicted from cache', function() {
+    it('should be possible to pop an evicted value when items are evicted from cache', function() {
       var cache = new Cache(3);
 
       cache.set('one', 1);
       cache.set('two', 2);
       cache.set('three', 3);
 
-      var evictedValue = 0;
-      var evictedKey = '';
-      var isOverwritten = false;
-      cache.setWithCallback('four', 4, function(v, k, overwritten) {
-        evictedKey = k;
-        evictedValue = v;
-        isOverwritten = overwritten;
-      });
-
+      var popResult = cache.setpop('four', 4);
+      assert.deepEqual(popResult, {evicted: true, key: 'one', value: 1});
       assert.deepEqual(Array.from(cache.values()), [4, 3, 2]);
-      assert.equal(evictedKey, 'one');
-      assert.equal(evictedValue, 1);
-      assert.equal(isOverwritten, false);
     });
 
     it('should be possible to get a callback when items are overwritten from cache', function() {
@@ -140,19 +130,9 @@ function makeTests(Cache, name) {
       cache.set('two', 2);
       cache.set('three', 3);
 
-      var overwrittenValue = 0;
-      var overwrittenKey = '';
-      var isOverwritten = false;
-      cache.setWithCallback('three', 10, function(v, k, overwritten) {
-        overwrittenKey = k;
-        overwrittenValue = v;
-        isOverwritten = overwritten;
-      });
-
+      var popResult = cache.setpop('three', 10);
+      assert.deepEqual(popResult, {evicted: false, key: 'three', value: 3});
       assert.deepEqual(Array.from(cache.values()), [10, 2, 1]);
-      assert.equal(overwrittenKey, 'three');
-      assert.equal(overwrittenValue, 3);
-      assert.equal(isOverwritten, true);
     });
 
     it('should work with capacity = 1.', function() {

--- a/test/lru-cache.js
+++ b/test/lru-cache.js
@@ -118,13 +118,16 @@ function makeTests(Cache, name) {
       cache.set('two', 2);
       cache.set('three', 3);
 
-      var result = 0;
-      cache.set('four', 4, function(v) {
-        result = v;
+      var evictedValue = 0;
+      var evictedKey = '';
+      cache.set('four', 4, function(k, v) {
+        evictedKey = k;
+        evictedValue = v;
       });
 
       assert.deepEqual(Array.from(cache.values()), [4, 3, 2]);
-      assert.equal(result, 1);
+      assert.equal(evictedKey, 'one');
+      assert.equal(evictedValue, 1);
     });
 
     it('should work with capacity = 1.', function() {


### PR DESCRIPTION
For our image visualization [project](https://github.com/CARTAvis/carta-frontend), I'm making use of mnemonist to keep track of texture tiles stored on the GPU. However, when new tiles are added to a LRU cache, I needed to add a callback, in order to perform some minor cleanup code when older tiles are evicted, or tiles are overwritten. 

I've added an additional function `setWithCallback`, with a callback that fires when an entry in the cache is evicted or overwritten. The callback takes three parameters: the value, the key and a boolean indicating whether the value is being overwritten. 

I've left the existing `set` function as is, as it may be faster if no check for a callback is required. In terms of alternative implementations, Android library has a [LruCache](https://developer.android.com/reference/android/util/LruCache) that allows for similar functionality, but handles in a slightly different manner. One possible alternative could be to pass the callback once during the construction of `LRUCache`, but this would mean that every call to `set` also checks for the existence of a callback. 