### PR TITLE
stricter types: noImplicitAny & noImplicitReturns

### DIFF
--- a/bit-set.d.ts
+++ b/bit-set.d.ts
@@ -13,9 +13,9 @@ export default class BitSet implements Iterable<number> {
 
   // Methods
   clear(): void;
-  set(index: number, value?: boolean | number);
-  reset(index: number, value: boolean | number);
-  flip(index: number, value: boolean | number);
+  set(index: number, value?: boolean | number): void;
+  reset(index: number, value: boolean | number): void;
+  flip(index: number, value: boolean | number): void;
   get(index: number): number;
   test(index: number): boolean;
   rank(r: number): number;

--- a/bit-vector.d.ts
+++ b/bit-vector.d.ts
@@ -22,8 +22,8 @@ export default class BitVector implements Iterable<number> {
   // Methods
   clear(): void;
   set(index: number, value?: boolean | number): this;
-  reset(index: number, value: boolean | number);
-  flip(index: number, value: boolean | number);
+  reset(index: number, value: boolean | number): void;
+  flip(index: number, value: boolean | number): void;
   reallocate(capacity: number): this;
   grow(capacity?: number): this;
   resize(length: number): this;

--- a/bloom-filter.d.ts
+++ b/bloom-filter.d.ts
@@ -25,5 +25,5 @@ export default class BloomFilter {
   toJSON(): Uint8Array;
 
   // Statics
-  from(iterable: Iterable<string>, options?: number | BloomFilterOptions);
+  from(iterable: Iterable<string>, options?: number | BloomFilterOptions): BloomFilter;
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "eslint ./*.js ./utils ./test",
     "prepublish": "npm run lint && npm test && npm run test:types",
     "test": "mocha",
-    "test:types": "tsc --lib es2015,dom --noEmit ./test/types.ts"
+    "test:types": "tsc --lib es2015,dom --noEmit --noImplicitAny --noImplicitReturns ./test/types.ts"
   },
   "files": [
     "utils",

--- a/utils/types.d.ts
+++ b/utils/types.d.ts
@@ -6,11 +6,11 @@
  */
 export interface IArrayLike {
   length: number;
-  slice(from, to?): IArrayLike;
+  slice(from: number, to?: number): IArrayLike;
 }
 
 export type ArrayLike = IArrayLike | ArrayBuffer;
 
 export interface IArrayLikeConstructor {
-  new(...args): ArrayLike;
+  new(...args: any[]): ArrayLike;
 }


### PR DESCRIPTION
Adds support for slightly tighter type checks with two popular TS checks. We use them on the project and can't really add mnemonist as a dependency without these two.

This change is backwards compatible, so will work fine with anyone using the types already.