### PR TITLE
fix(bit-set/vector): wrong size counting when (re)set last bit

### DIFF
--- a/bit-set.js
+++ b/bit-set.js
@@ -62,8 +62,8 @@ BitSet.prototype.set = function(index, value) {
   // The operands of all bitwise operators are converted to *signed* 32-bit integers.
   // Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Signed_32-bit_integers
   // Shifting by 31 changes the sign (i.e. 1 << 31 = -2147483648).
-  // Therefore, get the unsigned representation by shifting with `>>> 0`.
-  newBytes = newBytes >>> 0;
+  // Therefore, get absolute value.
+  newBytes = Math.abs(newBytes);
 
   // Updating size
   if (newBytes > oldBytes)
@@ -108,8 +108,7 @@ BitSet.prototype.flip = function(index) {
 
   var newBytes = this.array[byteIndex] ^= (1 << pos);
 
-  // Get unsigned representation
-  newBytes = newBytes >>> 0;
+  newBytes = Math.abs(newBytes);
 
   // Updating size
   if (newBytes > oldBytes)

--- a/bit-set.js
+++ b/bit-set.js
@@ -59,6 +59,12 @@ BitSet.prototype.set = function(index, value) {
   else
     newBytes = this.array[byteIndex] |= (1 << pos);
 
+  // The operands of all bitwise operators are converted to *signed* 32-bit integers.
+  // Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Signed_32-bit_integers
+  // Shifting by 31 changes the sign (i.e. 1 << 31 = -2147483648).
+  // Therefore, get the unsigned representation by shifting with `>>> 0`.
+  newBytes = newBytes >>> 0;
+
   // Updating size
   if (newBytes > oldBytes)
     this.size++;

--- a/bit-set.js
+++ b/bit-set.js
@@ -108,6 +108,9 @@ BitSet.prototype.flip = function(index) {
 
   var newBytes = this.array[byteIndex] ^= (1 << pos);
 
+  // Get unsigned representation
+  newBytes = newBytes >>> 0;
+
   // Updating size
   if (newBytes > oldBytes)
     this.size++;

--- a/bit-vector.js
+++ b/bit-vector.js
@@ -75,8 +75,7 @@ BitVector.prototype.set = function(index, value) {
   else
     newBytes = this.array[byteIndex] |= (1 << pos);
 
-  // Get unsigned representation
-  newBytes = newBytes >>> 0;
+  newBytes = Math.abs(newBytes);
 
   // Updating size
   if (newBytes > oldBytes)
@@ -121,8 +120,7 @@ BitVector.prototype.flip = function(index) {
 
   var newBytes = this.array[byteIndex] ^= (1 << pos);
 
-  // Get unsigned representation
-  newBytes = newBytes >>> 0;
+  newBytes = Math.abs(newBytes);
 
   // Updating size
   if (newBytes > oldBytes)

--- a/bit-vector.js
+++ b/bit-vector.js
@@ -75,6 +75,9 @@ BitVector.prototype.set = function(index, value) {
   else
     newBytes = this.array[byteIndex] |= (1 << pos);
 
+  // Get unsigned representation
+  newBytes = newBytes >>> 0;
+
   // Updating size
   if (newBytes > oldBytes)
     this.size++;
@@ -117,6 +120,9 @@ BitVector.prototype.flip = function(index) {
       oldBytes = this.array[byteIndex];
 
   var newBytes = this.array[byteIndex] ^= (1 << pos);
+
+  // Get unsigned representation
+  newBytes = newBytes >>> 0;
 
   // Updating size
   if (newBytes > oldBytes)

--- a/test/bit-set.js
+++ b/test/bit-set.js
@@ -43,6 +43,14 @@ describe('BitSet', function() {
     assert.strictEqual(set.test(3), false);
   });
 
+  it('should count set bits when only last bit is set', function() {
+    var set = new BitSet(32);
+
+    set.set(31);
+
+    assert.strictEqual(set.size, 1);
+  });
+
   it('should be possible to reset bits.', function() {
     var set = new BitSet(4);
 

--- a/test/bit-set.js
+++ b/test/bit-set.js
@@ -59,6 +59,15 @@ describe('BitSet', function() {
     assert.strictEqual(set.size, 1);
   });
 
+  it('should count set bits when only last bit is reset', function() {
+    var set = new BitSet(32);
+
+    set.set(31);
+    set.reset(31);
+
+    assert.strictEqual(set.size, 0);
+  });
+
   it('should be possible to reset bits.', function() {
     var set = new BitSet(4);
 

--- a/test/bit-set.js
+++ b/test/bit-set.js
@@ -51,6 +51,14 @@ describe('BitSet', function() {
     assert.strictEqual(set.size, 1);
   });
 
+  it('should count set bits when only last bit is flipped', function() {
+    var set = new BitSet(32);
+
+    set.flip(31);
+
+    assert.strictEqual(set.size, 1);
+  });
+
   it('should be possible to reset bits.', function() {
     var set = new BitSet(4);
 

--- a/test/bit-vector.js
+++ b/test/bit-vector.js
@@ -60,6 +60,15 @@ describe('BitVector', function() {
     assert.strictEqual(set.size, 1);
   });
 
+  it('should count set bits when only last bit is reset', function() {
+    var set = new BitVector(32);
+
+    set.set(31);
+    set.reset(31);
+
+    assert.strictEqual(set.size, 0);
+  });
+
   it('should be possible to reset bits.', function() {
     var vector = new BitVector(4);
 

--- a/test/bit-vector.js
+++ b/test/bit-vector.js
@@ -44,6 +44,22 @@ describe('BitVector', function() {
     assert.strictEqual(vector.test(3), false);
   });
 
+  it('should count set bits when only last bit is set', function() {
+    var set = new BitVector(32);
+
+    set.set(31);
+
+    assert.strictEqual(set.size, 1);
+  });
+
+  it('should count set bits when only last bit is flipped', function() {
+    var set = new BitVector(32);
+
+    set.flip(31);
+
+    assert.strictEqual(set.size, 1);
+  });
+
   it('should be possible to reset bits.', function() {
     var vector = new BitVector(4);
 


### PR DESCRIPTION
### What
Get the unsigned representation of `newBytes` before updating size in `set()` & `reset()`.

### Why
```JavaScript
var set = new BitSet(32);
set.set(31); // resulted in set.size = -1
```

Due to bit-shifting we get a [signed representation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Signed_32-bit_integers). I.e. if we shift `1 >> 31` we get `-2147483648` which then causes problem when we check with `newBytes > oldBytes` if we need to increment `size`.