### PR TITLE
fix(bit-set/vector): counting set/flipped bits

### DIFF
--- a/bit-set.js
+++ b/bit-set.js
@@ -62,8 +62,8 @@ BitSet.prototype.set = function(index, value) {
   // The operands of all bitwise operators are converted to *signed* 32-bit integers.
   // Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Signed_32-bit_integers
   // Shifting by 31 changes the sign (i.e. 1 << 31 = -2147483648).
-  // Therefore, get absolute value.
-  newBytes = Math.abs(newBytes);
+  // Therefore, get unsigned representation by applying '>>> 0'.
+  newBytes = newBytes >>> 0;
 
   // Updating size
   if (newBytes > oldBytes)
@@ -108,7 +108,8 @@ BitSet.prototype.flip = function(index) {
 
   var newBytes = this.array[byteIndex] ^= (1 << pos);
 
-  newBytes = Math.abs(newBytes);
+  // Get unsigned representation.
+  newBytes = newBytes >>> 0;
 
   // Updating size
   if (newBytes > oldBytes)

--- a/bit-vector.js
+++ b/bit-vector.js
@@ -75,7 +75,8 @@ BitVector.prototype.set = function(index, value) {
   else
     newBytes = this.array[byteIndex] |= (1 << pos);
 
-  newBytes = Math.abs(newBytes);
+  // Get unsigned representation.
+  newBytes = newBytes >>> 0;
 
   // Updating size
   if (newBytes > oldBytes)
@@ -120,7 +121,8 @@ BitVector.prototype.flip = function(index) {
 
   var newBytes = this.array[byteIndex] ^= (1 << pos);
 
-  newBytes = Math.abs(newBytes);
+  // Get unsigned representation.
+  newBytes = newBytes >>> 0;
 
   // Updating size
   if (newBytes > oldBytes)

--- a/test/bit-set.js
+++ b/test/bit-set.js
@@ -51,12 +51,24 @@ describe('BitSet', function() {
     assert.strictEqual(set.size, 1);
   });
 
-  it('should count set bits when only last bit is flipped', function() {
+  it('should count set bits', function() {
     var set = new BitSet(32);
 
-    set.flip(31);
+    for (let i = 0; i < 32; i++) {
+      set.set(i);
 
-    assert.strictEqual(set.size, 1);
+      assert.strictEqual(set.size, i + 1);
+    }
+  });
+
+  it('should count set bits when flipping bits', function() {
+    var set = new BitSet(32);
+
+    for (let i = 0; i < 32; i++) {
+      set.flip(i);
+
+      assert.strictEqual(set.size, i + 1);
+    }
   });
 
   it('should count set bits when only last bit is reset', function() {

--- a/test/bit-vector.js
+++ b/test/bit-vector.js
@@ -52,12 +52,24 @@ describe('BitVector', function() {
     assert.strictEqual(set.size, 1);
   });
 
-  it('should count set bits when only last bit is flipped', function() {
+  it('should count set bits', function() {
     var set = new BitVector(32);
 
-    set.flip(31);
+    for (let i = 0; i < 32; i++) {
+      set.set(i);
 
-    assert.strictEqual(set.size, 1);
+      assert.strictEqual(set.size, i + 1);
+    }
+  });
+
+  it('should count set bits when flipping bits', function() {
+    var set = new BitVector(32);
+
+    for (let i = 0; i < 32; i++) {
+      set.flip(i);
+
+      assert.strictEqual(set.size, i + 1);
+    }
   });
 
   it('should count set bits when only last bit is reset', function() {


### PR DESCRIPTION
### What

- Use `>>> 0` to get the correct unsigned representation
- Added test which sets all bits and checks the new `size` after each change

### Why

If we set **only** the bit at position 31 we get:
`-2147483648 (base 10) = 10000000000000000000000000000000 (base 2)`

If we apply `Math.abs(1 << 31)` we get the correct `2147483648`.

BUT if we set **all** bits we get `-1`:
`-1 (base 10) = 11111111111111111111111111111111 (base 2)`
[MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Signed_32-bit_integers): `The number -1 is the integer that is composed completely of 1 bits.`

If we apply now `Math.abs()` we get `1` instead of `4294967295` (`2³² - 1`)
which causes `1 < 2147483648` to be `true` and decrements `size` which is incorrect.

Therefore, we need to use `>>> 0` to get the correct unsigned representation.

### Performance

The above solution is less performant but correct. See results gattered by running `node benchmark/bit-set/performance.js`.

**Before:**
```
Bits: 1563.953ms
Bits: 1557.031ms
Bits: 1556.024ms
Bits: 1558.704ms
Bits: 1558.928ms
Bits: 1555.614ms
Bits: 1553.671ms
Bits: 1558.298ms
Bits: 1552.248ms
Bits: 1553.897ms

```

**After:**
```
Bits: 1713.413ms
Bits: 1706.475ms
Bits: 1705.256ms
Bits: 1708.838ms
Bits: 1713.719ms
Bits: 1707.608ms
Bits: 1709.821ms
Bits: 1708.039ms
Bits: 1711.698ms
Bits: 1705.497ms
```