### PR TITLE
Improve MultiMap typings

### DIFF
--- a/multi-map.d.ts
+++ b/multi-map.d.ts
@@ -2,14 +2,12 @@
  * Mnemonist MultiMap Typings
  * ===========================
  */
-export default class MultiMap<K, V> implements Iterable<[K, V]> {
+
+interface MultiMap<K, V, C extends V[] | Set<V> = V[]> extends Iterable<[K, V]> {
 
   // Members
   dimension: number;
   size: number;
-
-  // Constructor
-  constructor(Container?: ArrayConstructor | SetConstructor);
 
   // Methods
   clear(): void;
@@ -17,22 +15,33 @@ export default class MultiMap<K, V> implements Iterable<[K, V]> {
   delete(key: K): boolean;
   remove(key: K, value: V): boolean;
   has(key: K): boolean;
-  get(key: K): Array<V> | Set<V> | undefined;
+  get(key: K): C | undefined;
   multiplicity(key: K): number;
   forEach(callback: (value: V, key: K, map: this) => void, scope?: any): void;
-  forEachAssociation(callback: (value: Array<V> | Set<V>, key: K, map: this) => void, scope?: any): void;
-  keys(): Iterator<K>;
-  values(): Iterator<V>;
-  entries(): Iterator<[K, V]>;
-  containers(): Iterator<Array<V> | Set<V>>;
-  associations(): Iterator<[K, Array<V> | Set<V>]>;
-  [Symbol.iterator](): Iterator<[K, V]>;
+  forEachAssociation(callback: (value: C, key: K, map: this) => void, scope?: any): void;
+  keys(): IterableIterator<K>;
+  values(): IterableIterator<V>;
+  entries(): IterableIterator<[K, V]>;
+  containers(): IterableIterator<C>;
+  associations(): IterableIterator<[K, C]>;
+  [Symbol.iterator](): IterableIterator<[K, V]>;
   inspect(): any;
   toJSON(): any;
-
-  // Statics
-  static from<I, J>(
-    iterable: Iterable<[I, J]> | {[key: string]: J},
-    Container?: ArrayConstructor | SetConstructor
-  ): MultiMap<I, J>;
 }
+
+interface MultiMapConstructor {
+  new <K, V>(container: SetConstructor): MultiMap<K, V, Set<V>>;
+  new <K, V>(container?: ArrayConstructor): MultiMap<K, V, V[]>;
+
+  from<K, V>(
+    iterable: Iterable<[K, V]> | {[key: string]: V},
+    Container: SetConstructor
+  ): MultiMap<K, V, Set<V>>;
+  from<K, V>(
+    iterable: Iterable<[K, V]> | {[key: string]: V},
+    Container?: ArrayConstructor
+  ): MultiMap<K, V, V[]>;
+}
+
+declare const MultiMap: MultiMapConstructor;
+export default MultiMap;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "eslint ./*.js ./utils ./test",
     "prepublish": "npm run lint && npm test && npm run test:types",
     "test": "mocha",
-    "test:types": "tsc --lib es2015,dom --noEmit --noImplicitAny --noImplicitReturns ./test/types.ts"
+    "test:types": "tsc --target es2015 --noEmit --noImplicitAny --noImplicitReturns ./test/types.ts"
   },
   "files": [
     "utils",

--- a/test/multi-map.js
+++ b/test/multi-map.js
@@ -201,6 +201,8 @@ describe('MultiMap', function() {
 
     assert.strictEqual(iterator.next().value, 'one');
     assert.strictEqual(iterator.next().value, 'two');
+
+    assert.deepStrictEqual([...map.keys()], ['one', 'two']);
   });
 
   it('should be possible to create an iterator over the map\'s values.', function() {
@@ -218,6 +220,8 @@ describe('MultiMap', function() {
     assert.strictEqual(iterator.next().value, 'hello');
     assert.strictEqual(iterator.next().done, true);
 
+    assert.deepStrictEqual([...map.values()], ['hello', 'world', 'hello']);
+
     map = new MultiMap();
 
     map.set('one', 'hello');
@@ -230,6 +234,8 @@ describe('MultiMap', function() {
     assert.strictEqual(iterator.next().value, 'world');
     assert.strictEqual(iterator.next().value, 'hello');
     assert.strictEqual(iterator.next().done, true);
+
+    assert.deepStrictEqual([...map.values()], ['hello', 'world', 'hello']);
   });
 
   it('should be possible to create an iterator over the map\'s entries.', function() {
@@ -247,6 +253,8 @@ describe('MultiMap', function() {
     assert.deepEqual(iterator.next().value, ['two', 'hello']);
     assert.strictEqual(iterator.next().done, true);
 
+    assert.deepStrictEqual([...map.entries()], [['one', 'hello'], ['one', 'world'], ['two', 'hello']]);
+
     map = new MultiMap();
 
     map.set('one', 'hello');
@@ -259,6 +267,8 @@ describe('MultiMap', function() {
     assert.deepEqual(iterator.next().value, ['one', 'world']);
     assert.deepEqual(iterator.next().value, ['two', 'hello']);
     assert.strictEqual(iterator.next().done, true);
+
+    assert.deepStrictEqual([...map.entries()], [['one', 'hello'], ['one', 'world'], ['two', 'hello']]);
   });
 
   it('should be possible to create an iterator over the map\'s containers.', function() {
@@ -275,6 +285,8 @@ describe('MultiMap', function() {
     assert.deepEqual(iterator.next().value, new Set(['hello']));
     assert.strictEqual(iterator.next().done, true);
 
+    assert.deepStrictEqual([...map.containers()], [new Set(['hello', 'world']), new Set(['hello'])]);
+
     map = new MultiMap();
 
     map.set('one', 'hello');
@@ -286,6 +298,8 @@ describe('MultiMap', function() {
     assert.deepEqual(iterator.next().value, ['hello', 'world']);
     assert.deepEqual(iterator.next().value, ['hello']);
     assert.strictEqual(iterator.next().done, true);
+
+    assert.deepStrictEqual([...map.containers()], [['hello', 'world'], ['hello']]);
   });
 
   it('should be possible to create an iterator over the map\'s associations.', function() {
@@ -302,6 +316,11 @@ describe('MultiMap', function() {
     assert.deepEqual(iterator.next().value, ['two', new Set(['hello'])]);
     assert.strictEqual(iterator.next().done, true);
 
+    assert.deepStrictEqual(
+      [...map.associations()],
+      [['one', new Set(['hello', 'world'])], ['two', new Set(['hello'])]]
+    );
+
     map = new MultiMap();
 
     map.set('one', 'hello');
@@ -313,6 +332,11 @@ describe('MultiMap', function() {
     assert.deepEqual(iterator.next().value, ['one', ['hello', 'world']]);
     assert.deepEqual(iterator.next().value, ['two', ['hello']]);
     assert.strictEqual(iterator.next().done, true);
+
+    assert.deepStrictEqual(
+      [...map.associations()],
+      [['one', ['hello', 'world']], ['two', ['hello']]]
+    );
   });
 
   it('should be possible to iterate over the map using for...of.', function() {
@@ -331,6 +355,8 @@ describe('MultiMap', function() {
     }
 
     assert.strictEqual(i, 3);
+
+    assert.deepStrictEqual([...map], [['one', 'hello'], ['one', 'world'], ['two', 'hello']]);
   });
 
   it('should be possible to create a map from an abitrary iterable.', function() {

--- a/test/types.ts
+++ b/test/types.ts
@@ -38,8 +38,6 @@ import {
   VPTree
 } from '../index';
 
-import leven from 'leven';
-
 /**
  * BiMap.
  */
@@ -175,14 +173,22 @@ multiset = MultiSet.from({'one': 1});
 /**
  * MultiMap.
  */
-let multimap: MultiMap<number, string> = new MultiMap(Set);
+let multimap: MultiMap<number, string, Set<string>> = new MultiMap(Set);
 multimap.set(45, 'test');
+multimap.get(45).has('test');
 let stringMultimap: MultiMap<string, number> = MultiMap.from({one: 1});
+stringMultimap.get('one').indexOf(1);
+for (const _ of multimap) { }
+for (const _ of multimap.keys()) { }
+for (const _ of multimap.values()) { }
+for (const _ of multimap.entries()) { }
+for (const _ of multimap.containers()) { }
+for (const _ of multimap.associations()) { }
 
 /**
  * PassjoinIndex.
  */
-const passjoinIndex: PassjoinIndex<string> = new PassjoinIndex(leven, 1);
+const passjoinIndex: PassjoinIndex<string> = new PassjoinIndex(() => 0, 1);
 
 let passjoinResults: Set<string> = passjoinIndex.search('hello');
 

--- a/test/types.ts
+++ b/test/types.ts
@@ -188,7 +188,7 @@ for (const _ of multimap.associations()) { }
 /**
  * PassjoinIndex.
  */
-const passjoinIndex: PassjoinIndex<string> = new PassjoinIndex(() => 0, 1);
+const passjoinIndex: PassjoinIndex<string> = new PassjoinIndex((a: string, b: string) => 0, 1);
 
 let passjoinResults: Set<string> = passjoinIndex.search('hello');
 


### PR DESCRIPTION
1) Add container type as a type parameter to `MultiMap`.
2) Make `keys()`, `values()` etc return `IterableIterator` so that they can be used in `for ... of` statements and with the spread operator.