### PR TITLE
Omit undefined args in a DefaultMap's factory

### DIFF
--- a/default-map.d.ts
+++ b/default-map.d.ts
@@ -8,7 +8,7 @@ export default class DefaultMap<K, V> implements Iterable<[K, V]> {
   size: number;
 
   // Constructor
-  constructor(factory: (key?: K, index?: number) => V);
+  constructor(factory: (key: K, index: number) => V);
 
   // Methods
   clear(): void;


### PR DESCRIPTION
Both "key" and "index" arguments are never passed as `undefined` and it can be removed from the typings.

<details>
<summary>To understand this, let's dive in the code</summary>

```js
function DefaultMap(factory) {
  if (typeof factory !== 'function')
    throw new Error('mnemonist/FuzzyMultiMap.constructor: expecting a function.');

  this.items = new Map();
  this.factory = factory;  // the only write to this.factory
  this.size = 0;
}
```

And there is the only place where `this.factory` is called, with `key` and `this.size` values:

```js
DefaultMap.prototype.get = function(key) {
  var value = this.items.get(key);

  if (typeof value === 'undefined') {
    value = this.factory(key, this.size);
    this.items.set(key, value);
    this.size++;
  }

  return value;
};
```

According to the typings `get` can only be called with non-undefined type, thus `key` in `DefaultMap.prototype.get` is also non-undefined:

```ts
export default class DefaultMap<K, V> {
  get(key: K): V;
  // ...
}
```

`this.size = 0` is in the constructor, we just need to [check all writes to the field](https://github.com/Yomguithereal/mnemonist/blob/df5b8a55f1f3c0600a37d2665e933137606f0356/default-map.js):

```js
this.size = 0;
this.size++;
this.size = this.items.size;  // is always a number
```

That means `key` and `size` arguments are non-undefined. So we can replace `?: number` with `: number`.
</details>

That latest arguments still can be omitted as it is a common javascript property that is preserved by the typescript type system:

```js
new DefaultMap(() => ...)     // ok
new DefaultMap(k => ...)      // ok
new DefaultMap((k, i) => ...) // ok
```