### PR TITLE
chore: replace legacy deepEqual with deepStrictEqual

### DIFF
--- a/benchmark/kd-tree/sanity.js
+++ b/benchmark/kd-tree/sanity.js
@@ -23,7 +23,7 @@ var P;
 
 for (i = 0; i < KNN_TESTS; i++) {
   P = [Math.random(), Math.random()];
-  assert.deepEqual(new Set(tree.kNearestNeighbors(KNN, P)), new Set(tree.linearKNearestNeighbors(KNN, P)));
+  assert.deepStrictEqual(new Set(tree.kNearestNeighbors(KNN, P)), new Set(tree.linearKNearestNeighbors(KNN, P)));
 }
 
 var totalVisited = 0;

--- a/benchmark/passjoin-index/sanity.js
+++ b/benchmark/passjoin-index/sanity.js
@@ -52,7 +52,7 @@ function sanityTest(k) {
 
   // Sanity
   ACTUAL.forEach(function(_, i) {
-    assert.deepEqual(ACTUAL[i], EXPECTED[i]);
+    assert.deepStrictEqual(ACTUAL[i], EXPECTED[i]);
   });
 
   console.log();

--- a/test/_utils.js
+++ b/test/_utils.js
@@ -40,9 +40,9 @@ describe('utils', function() {
             abc = typed.concat(a, b, c),
             ba = typed.concat(b, a);
 
-        assert.deepEqual(Array.from(ab), [1, 2, 3, 4, 5]);
-        assert.deepEqual(Array.from(abc), [1, 2, 3, 4, 5, 5, 5, 6]);
-        assert.deepEqual(Array.from(ba), [4, 5, 1, 2, 3]);
+        assert.deepStrictEqual(Array.from(ab), [1, 2, 3, 4, 5]);
+        assert.deepStrictEqual(Array.from(abc), [1, 2, 3, 4, 5, 5, 5, 6]);
+        assert.deepStrictEqual(Array.from(ba), [4, 5, 1, 2, 3]);
       });
     });
   });
@@ -210,7 +210,7 @@ describe('utils', function() {
         ];
 
         tests.forEach(function(test) {
-          assert.deepEqual(merge.merge(test[0], test[1]), test[2]);
+          assert.deepStrictEqual(merge.merge(test[0], test[1]), test[2]);
         });
       });
 
@@ -221,7 +221,7 @@ describe('utils', function() {
         ];
 
         tests.forEach(function(test) {
-          assert.deepEqual(merge.merge.apply(null, test[0]), test[1]);
+          assert.deepStrictEqual(merge.merge.apply(null, test[0]), test[1]);
         });
       });
     });
@@ -239,7 +239,7 @@ describe('utils', function() {
         ];
 
         tests.forEach(function(test) {
-          assert.deepEqual(merge.unionUnique(test[0], test[1]), test[2]);
+          assert.deepStrictEqual(merge.unionUnique(test[0], test[1]), test[2]);
         });
       });
 
@@ -250,7 +250,7 @@ describe('utils', function() {
         ];
 
         tests.forEach(function(test) {
-          assert.deepEqual(merge.unionUnique.apply(null, test[0]), test[1]);
+          assert.deepStrictEqual(merge.unionUnique.apply(null, test[0]), test[1]);
         });
       });
     });
@@ -269,7 +269,7 @@ describe('utils', function() {
         ];
 
         tests.forEach(function(test) {
-          assert.deepEqual(merge.intersectionUnique(test[0], test[1]), test[2]);
+          assert.deepStrictEqual(merge.intersectionUnique(test[0], test[1]), test[2]);
         });
       });
 
@@ -283,7 +283,7 @@ describe('utils', function() {
         ];
 
         tests.forEach(function(test) {
-          assert.deepEqual(merge.intersectionUnique.apply(null, test[0]), test[1]);
+          assert.deepStrictEqual(merge.intersectionUnique.apply(null, test[0]), test[1]);
         });
       });
     });

--- a/test/bi-map.js
+++ b/test/bi-map.js
@@ -152,15 +152,15 @@ describe('BiMap', function() {
 
     var iterator = map.entries();
 
-    assert.deepEqual(iterator.next().value, ['one', 'hello']);
-    assert.deepEqual(iterator.next().value, ['two', 'world']);
-    assert.deepEqual(iterator.next().done, true);
+    assert.deepStrictEqual(iterator.next().value, ['one', 'hello']);
+    assert.deepStrictEqual(iterator.next().value, ['two', 'world']);
+    assert.deepStrictEqual(iterator.next().done, true);
 
     iterator = map.inverse.entries();
 
-    assert.deepEqual(iterator.next().value, ['hello', 'one']);
-    assert.deepEqual(iterator.next().value, ['world', 'two']);
-    assert.deepEqual(iterator.next().done, true);
+    assert.deepStrictEqual(iterator.next().value, ['hello', 'one']);
+    assert.deepStrictEqual(iterator.next().value, ['world', 'two']);
+    assert.deepStrictEqual(iterator.next().done, true);
   });
 
   it('should be possible to iterate over the map using for...of.', function() {
@@ -184,6 +184,6 @@ describe('BiMap', function() {
     var map = BiMap.from(new Map([['one', 'hello'], ['two', 'world']]));
 
     assert.strictEqual(map.size, 2);
-    assert.deepEqual(map.get('one'), 'hello');
+    assert.deepStrictEqual(map.get('one'), 'hello');
   });
 });

--- a/test/bit-set.js
+++ b/test/bit-set.js
@@ -158,8 +158,8 @@ describe('BitSet', function() {
       return [j, bit];
     });
 
-    assert.deepEqual(obliterator.take(set.values()), array);
-    assert.deepEqual(obliterator.take(set.entries()), indexedArray);
+    assert.deepStrictEqual(obliterator.take(set.values()), array);
+    assert.deepStrictEqual(obliterator.take(set.entries()), indexedArray);
   });
 
   it('length divisible by 32 iteration, issue #117.', function() {
@@ -170,7 +170,7 @@ describe('BitSet', function() {
     var counter = 0;
 
     while (!result.done) {
-      assert.deepEqual(result.value, [counter, 0]);
+      assert.deepStrictEqual(result.value, [counter, 0]);
       result = iterator.next();
       counter++;
     }
@@ -184,6 +184,6 @@ describe('BitSet', function() {
     set.set(8);
     set.set(9);
 
-    assert.deepEqual(set.toJSON(), [772]);
+    assert.deepStrictEqual(set.toJSON(), [772]);
   });
 });

--- a/test/bit-vector.js
+++ b/test/bit-vector.js
@@ -159,8 +159,8 @@ describe('BitVector', function() {
       return [j, bit];
     });
 
-    assert.deepEqual(obliterator.take(vector.values()), array);
-    assert.deepEqual(obliterator.take(vector.entries()), indexedArray);
+    assert.deepStrictEqual(obliterator.take(vector.values()), array);
+    assert.deepStrictEqual(obliterator.take(vector.entries()), indexedArray);
   });
 
   it('length divisible by 32 iteration, issue #117.', function() {
@@ -171,7 +171,7 @@ describe('BitVector', function() {
     var counter = 0;
 
     while (!result.done) {
-      assert.deepEqual(result.value, [counter, 0]);
+      assert.deepStrictEqual(result.value, [counter, 0]);
       result = iterator.next();
       counter++;
     }
@@ -315,6 +315,6 @@ describe('BitVector', function() {
     set.set(8);
     set.set(9);
 
-    assert.deepEqual(set.toJSON(), [772]);
+    assert.deepStrictEqual(set.toJSON(), [772]);
   });
 });

--- a/test/bk-tree.js
+++ b/test/bk-tree.js
@@ -45,11 +45,11 @@ describe('BKTree', function() {
     tree.add('roman');
     tree.add('yellow');
 
-    assert.deepEqual(tree.search(1, 'mello'), [
+    assert.deepStrictEqual(tree.search(1, 'mello'), [
       {item: 'hello', distance: 1}
     ]);
 
-    assert.deepEqual(tree.search(2, 'mello'), [
+    assert.deepStrictEqual(tree.search(2, 'mello'), [
       {item: 'hello', distance: 1},
       {item: 'yellow', distance: 2}
     ]);
@@ -64,11 +64,11 @@ describe('BKTree', function() {
     tree.add({value: 'roman'});
     tree.add({value: 'yellow'});
 
-    assert.deepEqual(tree.search(1, 'mello'), [
+    assert.deepStrictEqual(tree.search(1, 'mello'), [
       {item: {value: 'hello'}, distance: 1}
     ]);
 
-    assert.deepEqual(tree.search(2, 'mello'), [
+    assert.deepStrictEqual(tree.search(2, 'mello'), [
       {item: {value: 'hello'}, distance: 1},
       {item: {value: 'yellow'}, distance: 2}
     ]);

--- a/test/bloom-filter.js
+++ b/test/bloom-filter.js
@@ -39,15 +39,15 @@ describe('BloomFilter', function() {
 
     filter.add('hello');
 
-    assert.deepEqual(Array.from(filter.data), [128, 0, 86, 65]);
+    assert.deepStrictEqual(Array.from(filter.data), [128, 0, 86, 65]);
 
     filter.add('world');
 
-    assert.deepEqual(Array.from(filter.data), [131, 130, 94, 89]);
+    assert.deepStrictEqual(Array.from(filter.data), [131, 130, 94, 89]);
 
     filter.add('longer string');
 
-    assert.deepEqual(Array.from(filter.data), [167, 130, 95, 121]);
+    assert.deepStrictEqual(Array.from(filter.data), [167, 130, 95, 121]);
   });
 
   it('should be possible to insert more items.', function() {
@@ -56,7 +56,7 @@ describe('BloomFilter', function() {
     for (var i = 0; i < filter.capacity; i++)
       filter.add(i % 2 ? ('hello' + i) : ('world' + i));
 
-    assert.deepEqual(Array.from(filter.data), [168, 120, 121, 113, 105, 114, 37, 230, 138, 115, 203, 112, 167, 31, 235, 139, 90, 200, 77, 118, 194, 243, 25, 93, 128, 18, 115, 178, 23, 200, 73, 134, 160, 117, 57, 192, 116, 205, 164, 241, 63, 169, 140, 184, 195, 92, 45, 15, 33, 254, 79, 217, 147, 240, 50, 100, 251, 96, 216, 34, 104, 35, 6, 17, 179, 77, 146, 178]);
+    assert.deepStrictEqual(Array.from(filter.data), [168, 120, 121, 113, 105, 114, 37, 230, 138, 115, 203, 112, 167, 31, 235, 139, 90, 200, 77, 118, 194, 243, 25, 93, 128, 18, 115, 178, 23, 200, 73, 134, 160, 117, 57, 192, 116, 205, 164, 241, 63, 169, 140, 184, 195, 92, 45, 15, 33, 254, 79, 217, 147, 240, 50, 100, 251, 96, 216, 34, 104, 35, 6, 17, 179, 77, 146, 178]);
   });
 
   it('should be possible to test items.', function() {

--- a/test/circular-buffer.js
+++ b/test/circular-buffer.js
@@ -43,23 +43,23 @@ describe('CircularBuffer', function() {
     buffer.push(3);
     buffer.push(4);
 
-    assert.deepEqual(buffer.toArray(), [2, 3, 4]);
+    assert.deepStrictEqual(buffer.toArray(), [2, 3, 4]);
     assert.strictEqual(buffer.size, 3);
 
     buffer.push(5);
 
-    assert.deepEqual(buffer.toArray(), [3, 4, 5]);
+    assert.deepStrictEqual(buffer.toArray(), [3, 4, 5]);
     assert.strictEqual(buffer.size, 3);
 
     buffer.push(6);
 
-    assert.deepEqual(buffer.toArray(), [4, 5, 6]);
+    assert.deepStrictEqual(buffer.toArray(), [4, 5, 6]);
     assert.strictEqual(buffer.size, 3);
 
     buffer.push(7);
     buffer.push(8);
 
-    assert.deepEqual(buffer.toArray(), [6, 7, 8]);
+    assert.deepStrictEqual(buffer.toArray(), [6, 7, 8]);
     assert.strictEqual(buffer.size, 3);
   });
 
@@ -71,23 +71,23 @@ describe('CircularBuffer', function() {
     buffer.unshift(3);
     buffer.unshift(4);
 
-    assert.deepEqual(buffer.toArray(), [4, 3, 2]);
+    assert.deepStrictEqual(buffer.toArray(), [4, 3, 2]);
     assert.strictEqual(buffer.size, 3);
 
     buffer.unshift(5);
 
-    assert.deepEqual(buffer.toArray(), [5, 4, 3]);
+    assert.deepStrictEqual(buffer.toArray(), [5, 4, 3]);
     assert.strictEqual(buffer.size, 3);
 
     buffer.unshift(6);
 
-    assert.deepEqual(buffer.toArray(), [6, 5, 4]);
+    assert.deepStrictEqual(buffer.toArray(), [6, 5, 4]);
     assert.strictEqual(buffer.size, 3);
 
     buffer.unshift(7);
     buffer.unshift(8);
 
-    assert.deepEqual(buffer.toArray(), [8, 7, 6]);
+    assert.deepStrictEqual(buffer.toArray(), [8, 7, 6]);
     assert.strictEqual(buffer.size, 3);
   });
 
@@ -100,7 +100,7 @@ describe('CircularBuffer', function() {
     buffer.clear();
 
     assert.strictEqual(buffer.size, 0);
-    assert.deepEqual(buffer.toArray(), []);
+    assert.deepStrictEqual(buffer.toArray(), []);
   });
 
   it('should be possible to peek.', function() {
@@ -203,28 +203,28 @@ describe('CircularBuffer', function() {
     buffer.push(2);
     buffer.pop();
 
-    assert.deepEqual(buffer.toArray(), new Uint8Array([1]));
+    assert.deepStrictEqual(buffer.toArray(), new Uint8Array([1]));
 
     buffer.push(3);
     buffer.push(4);
 
-    assert.deepEqual(buffer.toArray(), new Uint8Array([1, 3, 4]));
+    assert.deepStrictEqual(buffer.toArray(), new Uint8Array([1, 3, 4]));
 
     buffer.shift();
     buffer.shift();
 
-    assert.deepEqual(buffer.toArray(), new Uint8Array([4]));
+    assert.deepStrictEqual(buffer.toArray(), new Uint8Array([4]));
     buffer.pop();
-    assert.deepEqual(buffer.toArray(), new Uint8Array([]));
+    assert.deepStrictEqual(buffer.toArray(), new Uint8Array([]));
 
     buffer.push(5);
     buffer.push(6);
 
-    assert.deepEqual(buffer.toArray(), new Uint8Array([5, 6]));
+    assert.deepStrictEqual(buffer.toArray(), new Uint8Array([5, 6]));
 
     buffer.shift();
 
-    assert.deepEqual(buffer.toArray(), new Uint8Array([6]));
+    assert.deepStrictEqual(buffer.toArray(), new Uint8Array([6]));
   });
 
   it('should be possible to iterate over the buffer.', function() {
@@ -252,7 +252,7 @@ describe('CircularBuffer', function() {
     buffer.push(2);
     buffer.push(3);
 
-    assert.deepEqual(buffer.toArray(), new Uint8Array([1, 2, 3]));
+    assert.deepStrictEqual(buffer.toArray(), new Uint8Array([1, 2, 3]));
 
     assert(buffer.toArray() instanceof Uint8Array);
   });
@@ -260,7 +260,7 @@ describe('CircularBuffer', function() {
   it('should be possible to create a buffer from an arbitrary iterable.', function() {
     var buffer = CircularBuffer.from([1, 2, 3], Array);
 
-    assert.deepEqual(buffer.toArray(), [1, 2, 3]);
+    assert.deepStrictEqual(buffer.toArray(), [1, 2, 3]);
   });
 
   it('should be possible to create a values iterator.', function() {
@@ -282,9 +282,9 @@ describe('CircularBuffer', function() {
 
     var iterator = buffer.entries();
 
-    assert.deepEqual(iterator.next().value, [0, 1]);
-    assert.deepEqual(iterator.next().value, [1, 2]);
-    assert.deepEqual(iterator.next().value, [2, 3]);
+    assert.deepStrictEqual(iterator.next().value, [0, 1]);
+    assert.deepStrictEqual(iterator.next().value, [1, 2]);
+    assert.deepStrictEqual(iterator.next().value, [2, 3]);
     assert.strictEqual(iterator.next().done, true);
   });
 

--- a/test/critbit-tree-map.js
+++ b/test/critbit-tree-map.js
@@ -135,6 +135,6 @@ describe('CritBitTreeMap', function() {
       result.push([key, value]);
     });
 
-    assert.deepEqual(result, sortBy(data, s));
+    assert.deepStrictEqual(result, sortBy(data, s));
   });
 });

--- a/test/default-map.js
+++ b/test/default-map.js
@@ -25,19 +25,19 @@ describe('DefaultMap', function() {
     map.get('one').push(1);
     map.set('two', [2]);
 
-    assert.deepEqual(map.get('one'), [1]);
-    assert.deepEqual(map.get('two'), [2]);
+    assert.deepStrictEqual(map.get('one'), [1]);
+    assert.deepStrictEqual(map.get('two'), [2]);
 
     assert.strictEqual(map.size, 2);
 
-    assert.deepEqual(map.get('unknown'), []);
+    assert.deepStrictEqual(map.get('unknown'), []);
 
     assert.strictEqual(map.size, 3);
 
     map.clear();
 
     assert.strictEqual(map.size, 0);
-    assert.deepEqual(map.get('one'), []);
+    assert.deepStrictEqual(map.get('one'), []);
   });
 
   it('should be possible to delete keys.', function() {
@@ -64,7 +64,7 @@ describe('DefaultMap', function() {
       items.push([key, list]);
     });
 
-    assert.deepEqual(items, [
+    assert.deepStrictEqual(items, [
       ['one', [1]],
       ['two', [2]]
     ]);
@@ -81,11 +81,11 @@ describe('DefaultMap', function() {
       ['two', [2]]
     ];
 
-    assert.deepEqual(take(map.entries()), entries);
-    assert.deepEqual(take(map.keys()), entries.map(function(e) {
+    assert.deepStrictEqual(take(map.entries()), entries);
+    assert.deepStrictEqual(take(map.keys()), entries.map(function(e) {
       return e[0];
     }));
-    assert.deepEqual(take(map.values()), entries.map(function(e) {
+    assert.deepStrictEqual(take(map.values()), entries.map(function(e) {
       return e[1];
     }));
   });
@@ -103,7 +103,7 @@ describe('DefaultMap', function() {
 
     map.get('one').push(1);
 
-    assert.deepEqual(map.peek('one'), [1]);
+    assert.deepStrictEqual(map.peek('one'), [1]);
     assert.strictEqual(map.peek('two'), undefined);
     assert.strictEqual(map.size, 1);
     assert.strictEqual(map.has('two'), false);

--- a/test/default-weak-map.js
+++ b/test/default-weak-map.js
@@ -25,14 +25,14 @@ describe('DefaultWeakMap', function() {
     map.get(one).push(1);
     map.set(two, [2]);
 
-    assert.deepEqual(map.get(one), [1]);
-    assert.deepEqual(map.get(two), [2]);
+    assert.deepStrictEqual(map.get(one), [1]);
+    assert.deepStrictEqual(map.get(two), [2]);
 
-    assert.deepEqual(map.get(unknown), []);
+    assert.deepStrictEqual(map.get(unknown), []);
 
     map.clear();
 
-    assert.deepEqual(map.get(one), []);
+    assert.deepStrictEqual(map.get(one), []);
   });
 
   it('should be possible to delete keys.', function() {
@@ -53,7 +53,7 @@ describe('DefaultWeakMap', function() {
 
     map.get(one).push(1);
 
-    assert.deepEqual(map.peek(one), [1]);
+    assert.deepStrictEqual(map.peek(one), [1]);
     assert.strictEqual(map.peek(two), undefined);
     assert.strictEqual(map.has(two), false);
   });

--- a/test/fibonacci-heap.js
+++ b/test/fibonacci-heap.js
@@ -94,14 +94,14 @@ describe('FibonacciHeap', function() {
     heap.push({value: 34});
     heap.push({value: 2});
 
-    assert.deepEqual(heap.peek(), {value: 2});
+    assert.deepStrictEqual(heap.peek(), {value: 2});
 
     var maxHeap = new MaxFibonacciHeap(comparator);
 
     maxHeap.push({value: 34});
     maxHeap.push({value: 2});
 
-    assert.deepEqual(maxHeap.peek(), {value: 34});
+    assert.deepStrictEqual(maxHeap.peek(), {value: 34});
   });
 
   it('should be possible to create a heap from an iterable.', function() {

--- a/test/fixed-critbit-tree-map.js
+++ b/test/fixed-critbit-tree-map.js
@@ -149,6 +149,6 @@ describe('FixedCritBitTreeMap', function() {
       result.push([key, value]);
     });
 
-    assert.deepEqual(result, sortBy(data, s));
+    assert.deepStrictEqual(result, sortBy(data, s));
   });
 });

--- a/test/fixed-deque.js
+++ b/test/fixed-deque.js
@@ -58,7 +58,7 @@ describe('FixedDeque', function() {
     deque.clear();
 
     assert.strictEqual(deque.size, 0);
-    assert.deepEqual(deque.toArray(), []);
+    assert.deepStrictEqual(deque.toArray(), []);
   });
 
   it('should be possible to peek.', function() {
@@ -161,28 +161,28 @@ describe('FixedDeque', function() {
     deque.push(2);
     deque.pop();
 
-    assert.deepEqual(deque.toArray(), new Uint8Array([1]));
+    assert.deepStrictEqual(deque.toArray(), new Uint8Array([1]));
 
     deque.push(3);
     deque.push(4);
 
-    assert.deepEqual(deque.toArray(), new Uint8Array([1, 3, 4]));
+    assert.deepStrictEqual(deque.toArray(), new Uint8Array([1, 3, 4]));
 
     deque.shift();
     deque.shift();
 
-    assert.deepEqual(deque.toArray(), new Uint8Array([4]));
+    assert.deepStrictEqual(deque.toArray(), new Uint8Array([4]));
     deque.pop();
-    assert.deepEqual(deque.toArray(), new Uint8Array([]));
+    assert.deepStrictEqual(deque.toArray(), new Uint8Array([]));
 
     deque.push(5);
     deque.push(6);
 
-    assert.deepEqual(deque.toArray(), new Uint8Array([5, 6]));
+    assert.deepStrictEqual(deque.toArray(), new Uint8Array([5, 6]));
 
     deque.shift();
 
-    assert.deepEqual(deque.toArray(), new Uint8Array([6]));
+    assert.deepStrictEqual(deque.toArray(), new Uint8Array([6]));
   });
 
   it('should be possible to iterate over the deque.', function() {
@@ -210,7 +210,7 @@ describe('FixedDeque', function() {
     deque.push(2);
     deque.push(3);
 
-    assert.deepEqual(deque.toArray(), new Uint8Array([1, 2, 3]));
+    assert.deepStrictEqual(deque.toArray(), new Uint8Array([1, 2, 3]));
 
     assert(deque.toArray() instanceof Uint8Array);
   });
@@ -218,7 +218,7 @@ describe('FixedDeque', function() {
   it('should be possible to create a deque from an arbitrary iterable.', function() {
     var deque = FixedDeque.from([1, 2, 3], Array);
 
-    assert.deepEqual(deque.toArray(), [1, 2, 3]);
+    assert.deepStrictEqual(deque.toArray(), [1, 2, 3]);
   });
 
   it('should be possible to create a values iterator.', function() {
@@ -240,9 +240,9 @@ describe('FixedDeque', function() {
 
     var iterator = deque.entries();
 
-    assert.deepEqual(iterator.next().value, [0, 1]);
-    assert.deepEqual(iterator.next().value, [1, 2]);
-    assert.deepEqual(iterator.next().value, [2, 3]);
+    assert.deepStrictEqual(iterator.next().value, [0, 1]);
+    assert.deepStrictEqual(iterator.next().value, [1, 2]);
+    assert.deepStrictEqual(iterator.next().value, [2, 3]);
     assert.strictEqual(iterator.next().done, true);
   });
 

--- a/test/fixed-reverse-heap.js
+++ b/test/fixed-reverse-heap.js
@@ -26,14 +26,14 @@ describe('FixedReverseHeap', function() {
     heap.push(1);
     heap.push(8);
 
-    assert.deepEqual(heap.consume(), [1, 4, 8]);
+    assert.deepStrictEqual(heap.consume(), [1, 4, 8]);
     assert.strictEqual(heap.size, 0);
 
     heap.push(3);
     heap.push(34);
 
     assert.strictEqual(heap.size, 2);
-    assert.deepEqual(heap.consume(), [3, 34]);
+    assert.deepStrictEqual(heap.consume(), [3, 34]);
     assert.strictEqual(heap.size, 0);
   });
 
@@ -44,7 +44,7 @@ describe('FixedReverseHeap', function() {
     heap.push(1);
     heap.push(8);
 
-    assert.deepEqual(heap.toArray(), [1, 4, 8]);
+    assert.deepStrictEqual(heap.toArray(), [1, 4, 8]);
     assert.strictEqual(heap.size, 3);
   });
 
@@ -62,7 +62,7 @@ describe('FixedReverseHeap', function() {
     heap.push(0);
 
     assert.strictEqual(heap.size, 3);
-    assert.deepEqual(heap.consume(), new Uint8Array([0, 1, 3]));
+    assert.deepStrictEqual(heap.consume(), new Uint8Array([0, 1, 3]));
   });
 
   it('should return the same type of array as given to the constructor.', function() {
@@ -92,7 +92,7 @@ describe('FixedReverseHeap', function() {
     heap.push(0);
 
     assert.strictEqual(heap.size, 2);
-    assert.deepEqual(heap.consume(), new Uint8Array([0, 234]));
+    assert.deepStrictEqual(heap.consume(), new Uint8Array([0, 234]));
   });
 
   it('should work with a reverse comparator.', function() {
@@ -118,6 +118,6 @@ describe('FixedReverseHeap', function() {
     heap.push(0);
 
     assert.strictEqual(heap.size, 3);
-    assert.deepEqual(heap.consume(), new Uint8Array([234, 138, 90]));
+    assert.deepStrictEqual(heap.consume(), new Uint8Array([234, 138, 90]));
   });
 });

--- a/test/fixed-stack.js
+++ b/test/fixed-stack.js
@@ -54,7 +54,7 @@ describe('FixedStack', function() {
     stack.clear();
 
     assert.strictEqual(stack.size, 0);
-    assert.deepEqual(stack.toArray(), []);
+    assert.deepStrictEqual(stack.toArray(), []);
   });
 
   it('should be possible to peek.', function() {
@@ -109,7 +109,7 @@ describe('FixedStack', function() {
     stack.push(2);
     stack.push(3);
 
-    assert.deepEqual(stack.toArray(), new Uint8Array([3, 2, 1]));
+    assert.deepStrictEqual(stack.toArray(), new Uint8Array([3, 2, 1]));
 
     assert(stack.toArray() instanceof Uint8Array);
   });
@@ -117,7 +117,7 @@ describe('FixedStack', function() {
   it('should be possible to create a stack from an arbitrary iterable.', function() {
     var stack = FixedStack.from([1, 2, 3], Array);
 
-    assert.deepEqual(stack.toArray(), [3, 2, 1]);
+    assert.deepStrictEqual(stack.toArray(), [3, 2, 1]);
   });
 
   it('should be possible to create a values iterator.', function() {
@@ -139,9 +139,9 @@ describe('FixedStack', function() {
 
     var iterator = stack.entries();
 
-    assert.deepEqual(iterator.next().value, [0, 3]);
-    assert.deepEqual(iterator.next().value, [1, 2]);
-    assert.deepEqual(iterator.next().value, [2, 1]);
+    assert.deepStrictEqual(iterator.next().value, [0, 3]);
+    assert.deepStrictEqual(iterator.next().value, [1, 2]);
+    assert.deepStrictEqual(iterator.next().value, [2, 1]);
     assert.strictEqual(iterator.next().done, true);
   });
 

--- a/test/fuzzy-map.js
+++ b/test/fuzzy-map.js
@@ -66,8 +66,8 @@ describe('FuzzyMap', function() {
     map.set('Hello', {title: 'Hello'});
     map.set('World', {title: 'World'});
 
-    assert.deepEqual(map.get('HELLO'), {title: 'Hello'});
-    assert.deepEqual(map.get('shawarama'), undefined);
+    assert.deepStrictEqual(map.get('HELLO'), {title: 'Hello'});
+    assert.deepStrictEqual(map.get('shawarama'), undefined);
   });
 
   it('should be possible to test the existence of an item in the map.', function() {
@@ -94,7 +94,7 @@ describe('FuzzyMap', function() {
     var i = 0;
 
     map.forEach(function(value) {
-      assert.deepEqual(value, !i ? {title: 'Hello'} : {title: 'World'});
+      assert.deepStrictEqual(value, !i ? {title: 'Hello'} : {title: 'World'});
       i++;
     });
 
@@ -111,8 +111,8 @@ describe('FuzzyMap', function() {
 
     var iterator = map.values();
 
-    assert.deepEqual(iterator.next().value, {title: 'Hello'});
-    assert.deepEqual(iterator.next().value, {title: 'World'});
+    assert.deepStrictEqual(iterator.next().value, {title: 'Hello'});
+    assert.deepStrictEqual(iterator.next().value, {title: 'World'});
     assert.strictEqual(iterator.next().done, true);
   });
 
@@ -127,7 +127,7 @@ describe('FuzzyMap', function() {
     var i = 0;
 
     for (var value of map) {
-      assert.deepEqual(value, !i ? {title: 'Hello'} : {title: 'World'});
+      assert.deepStrictEqual(value, !i ? {title: 'Hello'} : {title: 'World'});
       i++;
     }
 
@@ -146,7 +146,7 @@ describe('FuzzyMap', function() {
     var map = FuzzyMap.from([{title: 'Hello'}, {title: 'World'}], [writeHash, readHash]);
 
     assert.strictEqual(map.size, 2);
-    assert.deepEqual(map.get('hellO'), {title: 'Hello'});
+    assert.deepStrictEqual(map.get('hellO'), {title: 'Hello'});
 
     var otherMap = new Map([
       ['Hello', {title: 'Hello'}],
@@ -156,6 +156,6 @@ describe('FuzzyMap', function() {
     map = FuzzyMap.from(otherMap, readHash, true);
 
     assert.strictEqual(map.size, 2);
-    assert.deepEqual(map.get('WOrlD'), {title: 'World'});
+    assert.deepStrictEqual(map.get('WOrlD'), {title: 'World'});
   });
 });

--- a/test/fuzzy-multi-map.js
+++ b/test/fuzzy-multi-map.js
@@ -71,8 +71,8 @@ describe('FuzzyMultiMap', function() {
     map.set('HellO', {title: 'Hello2'});
     map.set('World', {title: 'World'});
 
-    assert.deepEqual(map.get('HELLO'), [{title: 'Hello1'}, {title: 'Hello2'}]);
-    assert.deepEqual(map.get('shawarama'), undefined);
+    assert.deepStrictEqual(map.get('HELLO'), [{title: 'Hello1'}, {title: 'Hello2'}]);
+    assert.deepStrictEqual(map.get('shawarama'), undefined);
   });
 
   it('should be possible to test the existence of an item in the map.', function() {
@@ -99,7 +99,7 @@ describe('FuzzyMultiMap', function() {
     var i = 0;
 
     map.forEach(function(value) {
-      assert.deepEqual(value, !i ? {title: 'Hello'} : {title: 'World'});
+      assert.deepStrictEqual(value, !i ? {title: 'Hello'} : {title: 'World'});
       i++;
     });
 
@@ -116,8 +116,8 @@ describe('FuzzyMultiMap', function() {
 
     var iterator = map.values();
 
-    assert.deepEqual(iterator.next().value, {title: 'Hello'});
-    assert.deepEqual(iterator.next().value, {title: 'World'});
+    assert.deepStrictEqual(iterator.next().value, {title: 'Hello'});
+    assert.deepStrictEqual(iterator.next().value, {title: 'World'});
     assert.strictEqual(iterator.next().done, true);
   });
 
@@ -132,7 +132,7 @@ describe('FuzzyMultiMap', function() {
     var i = 0;
 
     for (var value of map) {
-      assert.deepEqual(value, !i ? {title: 'Hello'} : {title: 'World'});
+      assert.deepStrictEqual(value, !i ? {title: 'Hello'} : {title: 'World'});
       i++;
     }
 
@@ -151,7 +151,7 @@ describe('FuzzyMultiMap', function() {
     var map = FuzzyMultiMap.from([{title: 'Hello'}, {title: 'World'}], [writeHash, readHash]);
 
     assert.strictEqual(map.size, 2);
-    assert.deepEqual(map.get('hellO'), [{title: 'Hello'}]);
+    assert.deepStrictEqual(map.get('hellO'), [{title: 'Hello'}]);
 
     var otherMap = new Map([
       ['Hello', {title: 'Hello'}],
@@ -161,7 +161,7 @@ describe('FuzzyMultiMap', function() {
     map = FuzzyMultiMap.from(otherMap, readHash, true);
 
     assert.strictEqual(map.size, 2);
-    assert.deepEqual(map.get('WOrlD'), [{title: 'World'}]);
+    assert.deepStrictEqual(map.get('WOrlD'), [{title: 'World'}]);
   });
 
   it('should work with a Set container.', function() {
@@ -180,7 +180,7 @@ describe('FuzzyMultiMap', function() {
 
     var set = map.get('hello');
 
-    assert.deepEqual(Array.from(set), [
+    assert.deepStrictEqual(Array.from(set), [
       {title: 'Hello1'},
       {title: 'Hello2'},
       {title: 'Hello3'}

--- a/test/heap.js
+++ b/test/heap.js
@@ -85,7 +85,7 @@ describe('Heap', function() {
 
     assert.strictEqual(heap.size, 2);
     assert.strictEqual(popped, 4);
-    assert.deepEqual(heap.toArray(), [5, 6]);
+    assert.deepStrictEqual(heap.toArray(), [5, 6]);
   });
 
   it('should be possible to create a max heap.', function() {
@@ -127,24 +127,24 @@ describe('Heap', function() {
     heap.push({value: 34});
     heap.push({value: 2});
 
-    assert.deepEqual(heap.peek(), {value: 2});
+    assert.deepStrictEqual(heap.peek(), {value: 2});
 
     var maxHeap = new MaxHeap(comparator);
 
     maxHeap.push({value: 34});
     maxHeap.push({value: 2});
 
-    assert.deepEqual(maxHeap.peek(), {value: 34});
+    assert.deepStrictEqual(maxHeap.peek(), {value: 34});
   });
 
   it('should be possible to convert the heap to an array.', function() {
     var heap = Heap.from([23, 1, 34, 5]);
 
-    assert.deepEqual(heap.toArray(), [1, 5, 23, 34]);
+    assert.deepStrictEqual(heap.toArray(), [1, 5, 23, 34]);
 
     heap = MaxHeap.from([23, 1, 34, 5]);
 
-    assert.deepEqual(heap.toArray(), [34, 23, 5, 1]);
+    assert.deepStrictEqual(heap.toArray(), [34, 23, 5, 1]);
   });
 
   it('should be possible to create a heap from an iterable.', function() {
@@ -162,7 +162,7 @@ describe('Heap', function() {
 
     var sorted = Heap.consume(DEFAULT_COMPARATOR, array);
 
-    assert.deepEqual(sorted, [0, 1, 3, 4, 5, 13, 56]);
+    assert.deepStrictEqual(sorted, [0, 1, 3, 4, 5, 13, 56]);
   });
 
   it('should be possible to fully consume the heap.', function() {
@@ -175,35 +175,35 @@ describe('Heap', function() {
     var array = heap.consume();
 
     assert.strictEqual(heap.size, 0);
-    assert.deepEqual(array, [-3, 0, 45]);
+    assert.deepStrictEqual(array, [-3, 0, 45]);
   });
 
   it('should be possible to get the n smallest items.', function() {
     var array = [5, 2, 4, 8, 9, 1, 45, 134, -34, 4, -1, 0];
 
-    assert.deepEqual(Heap.nsmallest(1, array), [-34]);
-    assert.deepEqual(Heap.nsmallest(34, array), [-34, -1, 0, 1, 2, 4, 4, 5, 8, 9, 45, 134]);
-    assert.deepEqual(Heap.nsmallest(3, array), [-34, -1, 0]);
+    assert.deepStrictEqual(Heap.nsmallest(1, array), [-34]);
+    assert.deepStrictEqual(Heap.nsmallest(34, array), [-34, -1, 0, 1, 2, 4, 4, 5, 8, 9, 45, 134]);
+    assert.deepStrictEqual(Heap.nsmallest(3, array), [-34, -1, 0]);
 
     var set = new Set(array);
 
-    assert.deepEqual(Heap.nsmallest(1, set.values()), [-34]);
-    assert.deepEqual(Heap.nsmallest(34, set.values()), [-34, -1, 0, 1, 2, 4, 5, 8, 9, 45, 134]);
-    assert.deepEqual(Heap.nsmallest(3, set.values()), [-34, -1, 0]);
+    assert.deepStrictEqual(Heap.nsmallest(1, set.values()), [-34]);
+    assert.deepStrictEqual(Heap.nsmallest(34, set.values()), [-34, -1, 0, 1, 2, 4, 5, 8, 9, 45, 134]);
+    assert.deepStrictEqual(Heap.nsmallest(3, set.values()), [-34, -1, 0]);
   });
 
   it('should be possible to get the n largest items.', function() {
     var array = [5, 2, 4, 8, 9, 1, 45, 134, -34, 4, -1, 0];
 
-    assert.deepEqual(Heap.nlargest(1, array), [134]);
-    assert.deepEqual(Heap.nlargest(34, array), [134, 45, 9, 8, 5, 4, 4, 2, 1, 0, -1, -34]);
-    assert.deepEqual(Heap.nlargest(3, array), [134, 45, 9]);
+    assert.deepStrictEqual(Heap.nlargest(1, array), [134]);
+    assert.deepStrictEqual(Heap.nlargest(34, array), [134, 45, 9, 8, 5, 4, 4, 2, 1, 0, -1, -34]);
+    assert.deepStrictEqual(Heap.nlargest(3, array), [134, 45, 9]);
 
     var set = new Set(array);
 
-    assert.deepEqual(Heap.nlargest(1, set.values()), [134]);
-    assert.deepEqual(Heap.nlargest(34, set.values()), [134, 45, 9, 8, 5, 4, 2, 1, 0, -1, -34]);
-    assert.deepEqual(Heap.nlargest(3, set.values()), [134, 45, 9]);
+    assert.deepStrictEqual(Heap.nlargest(1, set.values()), [134]);
+    assert.deepStrictEqual(Heap.nlargest(34, set.values()), [134, 45, 9, 8, 5, 4, 2, 1, 0, -1, -34]);
+    assert.deepStrictEqual(Heap.nlargest(3, set.values()), [134, 45, 9]);
   });
 
   it('should use the given comparator when n = 1, issue #120.', function() {
@@ -223,10 +223,10 @@ describe('Heap', function() {
 
     var first = Heap.nsmallest(comparator, 1, array);
 
-    assert.deepEqual(first, [9]);
+    assert.deepStrictEqual(first, [9]);
 
     first = Heap.nlargest(comparator, 1, array);
 
-    assert.deepEqual(first, [2]);
+    assert.deepStrictEqual(first, [2]);
   });
 });

--- a/test/inverted-index.js
+++ b/test/inverted-index.js
@@ -74,19 +74,19 @@ describe('InvertedIndex', function() {
     var index = InvertedIndex.from(DOCS, tokenizer);
 
     var results = index.get('A mouse.');
-    assert.deepEqual(results, DOCS);
+    assert.deepStrictEqual(results, DOCS);
 
     results = index.get('cheese');
-    assert.deepEqual(results, DOCS.slice(1));
+    assert.deepStrictEqual(results, DOCS.slice(1));
 
     results = index.get('The cat');
-    assert.deepEqual(results, [DOCS[0]]);
+    assert.deepStrictEqual(results, [DOCS[0]]);
 
     results = index.get('The cat likes');
-    assert.deepEqual(results, []);
+    assert.deepStrictEqual(results, []);
 
     results = index.get('really something');
-    assert.deepEqual(results, DOCS.slice(-1));
+    assert.deepStrictEqual(results, DOCS.slice(-1));
   });
 
   it('should be possible to iterate using #.forEach', function() {
@@ -103,9 +103,9 @@ describe('InvertedIndex', function() {
 
     var iterator = index.documents();
 
-    assert.deepEqual(iterator.next().value, OBJECT_DOCS[0]);
-    assert.deepEqual(iterator.next().value, OBJECT_DOCS[1]);
-    assert.deepEqual(iterator.next().value, OBJECT_DOCS[2]);
+    assert.deepStrictEqual(iterator.next().value, OBJECT_DOCS[0]);
+    assert.deepStrictEqual(iterator.next().value, OBJECT_DOCS[1]);
+    assert.deepStrictEqual(iterator.next().value, OBJECT_DOCS[2]);
     assert.strictEqual(iterator.next().done, true);
   });
 
@@ -114,13 +114,13 @@ describe('InvertedIndex', function() {
 
     var iterator = index.tokens();
 
-    assert.deepEqual(iterator.next().value, 'cat');
-    assert.deepEqual(iterator.next().value, 'eat');
-    assert.deepEqual(iterator.next().value, 'mouse');
-    assert.deepEqual(iterator.next().value, 'like');
-    assert.deepEqual(iterator.next().value, 'cheese');
-    assert.deepEqual(iterator.next().value, 'something');
-    assert.deepEqual(iterator.next().value, 'really');
+    assert.deepStrictEqual(iterator.next().value, 'cat');
+    assert.deepStrictEqual(iterator.next().value, 'eat');
+    assert.deepStrictEqual(iterator.next().value, 'mouse');
+    assert.deepStrictEqual(iterator.next().value, 'like');
+    assert.deepStrictEqual(iterator.next().value, 'cheese');
+    assert.deepStrictEqual(iterator.next().value, 'something');
+    assert.deepStrictEqual(iterator.next().value, 'really');
     assert.strictEqual(iterator.next().done, true);
   });
 });

--- a/test/kd-tree.js
+++ b/test/kd-tree.js
@@ -49,9 +49,9 @@ describe('KDTree', function() {
 
     assert.strictEqual(tree.nearestNeighbor([8, 5]), 'two');
 
-    assert.deepEqual(tree.pivots, new Uint8Array([5, 1, 0, 3, 2, 4]));
-    assert.deepEqual(tree.lefts, new Uint8Array([2, 3, 0, 0, 6, 0]));
-    assert.deepEqual(tree.rights, new Uint8Array([5, 4, 0, 0, 0, 0]));
+    assert.deepStrictEqual(tree.pivots, new Uint8Array([5, 1, 0, 3, 2, 4]));
+    assert.deepStrictEqual(tree.lefts, new Uint8Array([2, 3, 0, 0, 6, 0]));
+    assert.deepStrictEqual(tree.rights, new Uint8Array([5, 4, 0, 0, 0, 0]));
   });
 
   it('should be possible to build a KDTree directly from axes.', function() {
@@ -66,9 +66,9 @@ describe('KDTree', function() {
 
     assert.strictEqual(tree.nearestNeighbor([8, 5]), 'two');
 
-    assert.deepEqual(tree.pivots, new Uint8Array([5, 1, 0, 3, 2, 4]));
-    assert.deepEqual(tree.lefts, new Uint8Array([2, 3, 0, 0, 6, 0]));
-    assert.deepEqual(tree.rights, new Uint8Array([5, 4, 0, 0, 0, 0]));
+    assert.deepStrictEqual(tree.pivots, new Uint8Array([5, 1, 0, 3, 2, 4]));
+    assert.deepStrictEqual(tree.lefts, new Uint8Array([2, 3, 0, 0, 6, 0]));
+    assert.deepStrictEqual(tree.rights, new Uint8Array([5, 4, 0, 0, 0, 0]));
   });
 
   it('should be possible to build a KDTree from axes and without labels.', function() {
@@ -90,10 +90,10 @@ describe('KDTree', function() {
       assert.strictEqual(tree.nearestNeighbor(item[1]), tree.kNearestNeighbors(1, item[1])[0]);
 
       var nn2 = knn(2, item[1]);
-      assert.deepEqual(new Set(tree.kNearestNeighbors(2, item[1])), new Set(nn2));
+      assert.deepStrictEqual(new Set(tree.kNearestNeighbors(2, item[1])), new Set(nn2));
 
       var nn3 = knn(3, item[1]);
-      assert.deepEqual(new Set(tree.kNearestNeighbors(3, item[1])), new Set(nn3));
+      assert.deepStrictEqual(new Set(tree.kNearestNeighbors(3, item[1])), new Set(nn3));
     });
   });
 
@@ -104,6 +104,6 @@ describe('KDTree', function() {
       assert.strictEqual(tree.nearestNeighbor(item[1]), tree.linearKNearestNeighbors(1, item[1])[0]);
     });
 
-    assert.deepEqual(tree.linearKNearestNeighbors(3, [8, 3]), ['five', 'four', 'one']);
+    assert.deepStrictEqual(tree.linearKNearestNeighbors(3, [8, 3]), ['five', 'four', 'one']);
   });
 });

--- a/test/linked-list.js
+++ b/test/linked-list.js
@@ -23,7 +23,7 @@ describe('LinkedList', function() {
     list.unshift(1);
 
     assert.strictEqual(list.size, 3);
-    assert.deepEqual(list.toArray(), [1, 2, 3]);
+    assert.deepStrictEqual(list.toArray(), [1, 2, 3]);
   });
 
   it('should be possible to clear the list.', function() {
@@ -35,7 +35,7 @@ describe('LinkedList', function() {
     list.clear();
 
     assert.strictEqual(list.size, 0);
-    assert.deepEqual(list.toArray(), []);
+    assert.deepStrictEqual(list.toArray(), []);
   });
 
   it('should be possible to get the first & last items of the list.', function() {
@@ -123,9 +123,9 @@ describe('LinkedList', function() {
 
     var iterator = list.entries();
 
-    assert.deepEqual(iterator.next().value, [0, 1]);
-    assert.deepEqual(iterator.next().value, [1, 2]);
-    assert.deepEqual(iterator.next().value, [2, 3]);
+    assert.deepStrictEqual(iterator.next().value, [0, 1]);
+    assert.deepStrictEqual(iterator.next().value, [1, 2]);
+    assert.deepStrictEqual(iterator.next().value, [2, 3]);
     assert.strictEqual(iterator.next().done, true);
   });
 

--- a/test/lru-cache.js
+++ b/test/lru-cache.js
@@ -24,20 +24,20 @@ function makeTests(Cache, name) {
       cache.set('two', 2);
 
       assert.strictEqual(cache.size, 2);
-      assert.deepEqual(Array.from(cache.entries()), [['two', 2], ['one', 1]]);
+      assert.deepStrictEqual(Array.from(cache.entries()), [['two', 2], ['one', 1]]);
 
       cache.set('three', 3);
 
       assert.strictEqual(cache.size, 3);
-      assert.deepEqual(Array.from(cache.entries()), [['three', 3], ['two', 2], ['one', 1]]);
+      assert.deepStrictEqual(Array.from(cache.entries()), [['three', 3], ['two', 2], ['one', 1]]);
 
       cache.set('four', 4);
 
       assert.strictEqual(cache.size, 3);
-      assert.deepEqual(Array.from(cache.entries()), [['four', 4], ['three', 3], ['two', 2]]);
+      assert.deepStrictEqual(Array.from(cache.entries()), [['four', 4], ['three', 3], ['two', 2]]);
 
       cache.set('two', 5);
-      assert.deepEqual(Array.from(cache.entries()), [['two', 5], ['four', 4], ['three', 3]]);
+      assert.deepStrictEqual(Array.from(cache.entries()), [['two', 5], ['four', 4], ['three', 3]]);
 
       assert.strictEqual(cache.has('four'), true);
       assert.strictEqual(cache.has('one'), false);
@@ -45,16 +45,16 @@ function makeTests(Cache, name) {
       assert.strictEqual(cache.get('one'), undefined);
       assert.strictEqual(cache.get('four'), 4);
 
-      assert.deepEqual(Array.from(cache.entries()), [['four', 4], ['two', 5], ['three', 3]]);
+      assert.deepStrictEqual(Array.from(cache.entries()), [['four', 4], ['two', 5], ['three', 3]]);
 
       assert.strictEqual(cache.get('three'), 3);
-      assert.deepEqual(Array.from(cache.entries()), [['three', 3], ['four', 4], ['two', 5]]);
+      assert.deepStrictEqual(Array.from(cache.entries()), [['three', 3], ['four', 4], ['two', 5]]);
 
       assert.strictEqual(cache.get('three'), 3);
-      assert.deepEqual(Array.from(cache.entries()), [['three', 3], ['four', 4], ['two', 5]]);
+      assert.deepStrictEqual(Array.from(cache.entries()), [['three', 3], ['four', 4], ['two', 5]]);
 
       assert.strictEqual(cache.peek('two'), 5);
-      assert.deepEqual(Array.from(cache.entries()), [['three', 3], ['four', 4], ['two', 5]]);
+      assert.deepStrictEqual(Array.from(cache.entries()), [['three', 3], ['four', 4], ['two', 5]]);
 
       if (name === 'LRUCache')
         assert.strictEqual(Object.keys(cache.items).length, 3);
@@ -69,11 +69,11 @@ function makeTests(Cache, name) {
       cache.set('two', 2);
       cache.set('one', 3);
 
-      assert.deepEqual(Array.from(cache.entries()), [['one', 3], ['two', 2]]);
+      assert.deepStrictEqual(Array.from(cache.entries()), [['one', 3], ['two', 2]]);
 
       assert.strictEqual(cache.get('two'), 2);
 
-      assert.deepEqual(Array.from(cache.entries()), [['two', 2], ['one', 3]]);
+      assert.deepStrictEqual(Array.from(cache.entries()), [['two', 2], ['one', 3]]);
 
       cache.clear();
 
@@ -88,7 +88,7 @@ function makeTests(Cache, name) {
       cache.set('two', 6);
       cache.set('four', 4);
 
-      assert.deepEqual(Array.from(cache.entries()), [['four', 4], ['two', 6], ['three', 3]]);
+      assert.deepStrictEqual(Array.from(cache.entries()), [['four', 4], ['two', 6], ['three', 3]]);
     });
 
     it('should be possible to create an iterator over the cache\'s keys.', function() {
@@ -98,7 +98,7 @@ function makeTests(Cache, name) {
       cache.set('two', 2);
       cache.set('three', 3);
 
-      assert.deepEqual(Array.from(cache.keys()), ['three', 'two', 'one']);
+      assert.deepStrictEqual(Array.from(cache.keys()), ['three', 'two', 'one']);
     });
 
     it('should be possible to create an iterator over the cache\'s values.', function() {
@@ -108,7 +108,7 @@ function makeTests(Cache, name) {
       cache.set('two', 2);
       cache.set('three', 3);
 
-      assert.deepEqual(Array.from(cache.values()), [3, 2, 1]);
+      assert.deepStrictEqual(Array.from(cache.values()), [3, 2, 1]);
     });
 
     it('should be possible to pop an evicted value when items are evicted from cache', function() {
@@ -119,8 +119,8 @@ function makeTests(Cache, name) {
       cache.set('three', 3);
 
       var popResult = cache.setpop('four', 4);
-      assert.deepEqual(popResult, {evicted: true, key: 'one', value: 1});
-      assert.deepEqual(Array.from(cache.values()), [4, 3, 2]);
+      assert.deepStrictEqual(popResult, {evicted: true, key: 'one', value: 1});
+      assert.deepStrictEqual(Array.from(cache.values()), [4, 3, 2]);
     });
 
     it('should return null when setting an item does not overwrite or evict', function() {
@@ -140,8 +140,8 @@ function makeTests(Cache, name) {
       cache.set('three', 3);
 
       var popResult = cache.setpop('three', 10);
-      assert.deepEqual(popResult, {evicted: false, key: 'three', value: 3});
-      assert.deepEqual(Array.from(cache.values()), [10, 2, 1]);
+      assert.deepStrictEqual(popResult, {evicted: false, key: 'three', value: 3});
+      assert.deepStrictEqual(Array.from(cache.values()), [10, 2, 1]);
     });
 
     it('should work with capacity = 1.', function() {
@@ -151,18 +151,18 @@ function makeTests(Cache, name) {
       cache.set('two', 2);
       cache.set('three', 3);
 
-      assert.deepEqual(Array.from(cache.entries()), [['three', 3]]);
+      assert.deepStrictEqual(Array.from(cache.entries()), [['three', 3]]);
       assert.strictEqual(cache.get('one'), undefined);
       assert.strictEqual(cache.get('three'), 3);
       assert.strictEqual(cache.get('three'), 3);
 
-      assert.deepEqual(Array.from(cache.entries()), [['three', 3]]);
+      assert.deepStrictEqual(Array.from(cache.entries()), [['three', 3]]);
     });
 
     it('should be possible to create a cache from an arbitrary iterable.', function() {
       var cache = Cache.from(new Map([['one', 1], ['two', 2]]));
 
-      assert.deepEqual(Array.from(cache.entries()), [['two', 2], ['one', 1]]);
+      assert.deepStrictEqual(Array.from(cache.entries()), [['two', 2], ['one', 1]]);
     });
 
     it('should be possible to create a specialized cache.', function() {
@@ -173,7 +173,7 @@ function makeTests(Cache, name) {
       cache.set(23, 0.45);
       cache.set(59, -0.464);
 
-      assert.deepEqual(Array.from(cache.entries()), [[59, -0.464], [23, 0.45], [12, 6.464]]);
+      assert.deepStrictEqual(Array.from(cache.entries()), [[59, -0.464], [23, 0.45], [12, 6.464]]);
 
       var cacheFrom = Cache.from([], Uint8Array, Float64Array, 3);
 
@@ -182,7 +182,7 @@ function makeTests(Cache, name) {
       cacheFrom.set(23, 0.45);
       cacheFrom.set(59, -0.464);
 
-      assert.deepEqual(Array.from(cacheFrom.entries()), [[59, -0.464], [23, 0.45], [12, 6.464]]);
+      assert.deepStrictEqual(Array.from(cacheFrom.entries()), [[59, -0.464], [23, 0.45], [12, 6.464]]);
     });
 
     it('should be possible to iterate over the cache using a callback.', function() {
@@ -198,7 +198,7 @@ function makeTests(Cache, name) {
         entries.push([key, value]);
       });
 
-      assert.deepEqual(entries, Array.from(cache.entries()));
+      assert.deepStrictEqual(entries, Array.from(cache.entries()));
     });
 
     it('should be possible to iterate over the cache.', function() {
@@ -213,7 +213,7 @@ function makeTests(Cache, name) {
       for (var entry of cache)
         entries.push(entry);
 
-      assert.deepEqual(entries, Array.from(cache.entries()));
+      assert.deepStrictEqual(entries, Array.from(cache.entries()));
     });
   });
 }

--- a/test/multi-array.js
+++ b/test/multi-array.js
@@ -31,9 +31,9 @@ describe('MultiArray', function() {
 
     assert.strictEqual(array.size, 3);
     assert.strictEqual(array.dimension, 3);
-    assert.deepEqual(array.get(0), [1]);
-    assert.deepEqual(array.get(1), [2]);
-    assert.deepEqual(array.get(2), [3]);
+    assert.deepStrictEqual(array.get(0), [1]);
+    assert.deepStrictEqual(array.get(1), [2]);
+    assert.deepStrictEqual(array.get(2), [3]);
 
     array.set(0, 4);
     array.set(1, 5);
@@ -41,9 +41,9 @@ describe('MultiArray', function() {
 
     assert.strictEqual(array.size, 6);
     assert.strictEqual(array.dimension, 3);
-    assert.deepEqual(array.get(0), [1, 4]);
-    assert.deepEqual(array.get(1), [2, 5]);
-    assert.deepEqual(array.get(2), [3, 6]);
+    assert.deepStrictEqual(array.get(0), [1, 4]);
+    assert.deepStrictEqual(array.get(1), [2, 5]);
+    assert.deepStrictEqual(array.get(2), [3, 6]);
 
     array = new MultiArray(Uint8Array, 6);
 
@@ -53,9 +53,9 @@ describe('MultiArray', function() {
 
     assert.strictEqual(array.size, 3);
     assert.strictEqual(array.dimension, 3);
-    assert.deepEqual(array.get(0), new Uint8Array([1]));
-    assert.deepEqual(array.get(1), new Uint8Array([2]));
-    assert.deepEqual(array.get(2), new Uint8Array([3]));
+    assert.deepStrictEqual(array.get(0), new Uint8Array([1]));
+    assert.deepStrictEqual(array.get(1), new Uint8Array([2]));
+    assert.deepStrictEqual(array.get(2), new Uint8Array([3]));
 
     array.set(0, 4);
     array.set(1, 5);
@@ -63,9 +63,9 @@ describe('MultiArray', function() {
 
     assert.strictEqual(array.size, 6);
     assert.strictEqual(array.dimension, 3);
-    assert.deepEqual(array.get(0), new Uint8Array([1, 4]));
-    assert.deepEqual(array.get(1), new Uint8Array([2, 5]));
-    assert.deepEqual(array.get(2), new Uint8Array([3, 6]));
+    assert.deepStrictEqual(array.get(0), new Uint8Array([1, 4]));
+    assert.deepStrictEqual(array.get(1), new Uint8Array([2, 5]));
+    assert.deepStrictEqual(array.get(2), new Uint8Array([3, 6]));
 
     assert.throws(function() {
       array.push(45);
@@ -82,10 +82,10 @@ describe('MultiArray', function() {
     array.set(1, 5);
     array.set(2, 6);
 
-    assert.deepEqual(array.get(4), undefined);
-    assert.deepEqual(array.get(0), [1, 2, 3]);
-    assert.deepEqual(array.get(1), [4, 5]);
-    assert.deepEqual(array.get(2), [6]);
+    assert.deepStrictEqual(array.get(4), undefined);
+    assert.deepStrictEqual(array.get(0), [1, 2, 3]);
+    assert.deepStrictEqual(array.get(1), [4, 5]);
+    assert.deepStrictEqual(array.get(2), [6]);
 
     assert.strictEqual(array.has(4), false);
     assert.strictEqual(array.has(0), true);
@@ -137,8 +137,8 @@ describe('MultiArray', function() {
 
     assert.strictEqual(array.size, 3);
     assert.strictEqual(array.dimension, 35);
-    assert.deepEqual(array.get(2), [4, 5]);
-    assert.deepEqual(array.get(34), [3]);
+    assert.deepStrictEqual(array.get(2), [4, 5]);
+    assert.deepStrictEqual(array.get(34), [3]);
 
     array = new MultiArray(Uint8Array, 40);
 
@@ -148,8 +148,8 @@ describe('MultiArray', function() {
 
     assert.strictEqual(array.size, 3);
     assert.strictEqual(array.dimension, 35);
-    assert.deepEqual(Array.from(array.get(2)), [4, 5]);
-    assert.deepEqual(Array.from(array.get(34)), [3]);
+    assert.deepStrictEqual(Array.from(array.get(2)), [4, 5]);
+    assert.deepStrictEqual(Array.from(array.get(34)), [3]);
   });
 
   it('should be possible to iterate over containers.', function() {
@@ -162,7 +162,7 @@ describe('MultiArray', function() {
     array.set(1, 5);
     array.set(2, 6);
 
-    assert.deepEqual(take(array.containers()), [
+    assert.deepStrictEqual(take(array.containers()), [
       [1, 2, 3],
       [4, 5],
       [6]
@@ -179,7 +179,7 @@ describe('MultiArray', function() {
     array.set(1, 5);
     array.set(2, 6);
 
-    assert.deepEqual(take(array.associations()), [
+    assert.deepStrictEqual(take(array.associations()), [
       [0, [1, 2, 3]],
       [1, [4, 5]],
       [2, [6]]
@@ -196,11 +196,11 @@ describe('MultiArray', function() {
     array.set(1, 5);
     array.set(2, 6);
 
-    assert.deepEqual(take(array.values()), [1, 2, 3, 4, 5, 6]);
-    assert.deepEqual(take(array.values(0)), [3, 2, 1]);
-    assert.deepEqual(take(array.values(1)), [5, 4]);
-    assert.deepEqual(take(array.values(2)), [6]);
-    assert.deepEqual(take(array.values(3)), []);
+    assert.deepStrictEqual(take(array.values()), [1, 2, 3, 4, 5, 6]);
+    assert.deepStrictEqual(take(array.values(0)), [3, 2, 1]);
+    assert.deepStrictEqual(take(array.values(1)), [5, 4]);
+    assert.deepStrictEqual(take(array.values(2)), [6]);
+    assert.deepStrictEqual(take(array.values(3)), []);
   });
 
   it('should be possible to iterate over entries.', function() {
@@ -213,7 +213,7 @@ describe('MultiArray', function() {
     array.set(1, 5);
     array.set(2, 6);
 
-    assert.deepEqual(take(array.entries()), [
+    assert.deepStrictEqual(take(array.entries()), [
         [0, 3],
         [0, 2],
         [0, 1],
@@ -233,6 +233,6 @@ describe('MultiArray', function() {
     array.set(1, 5);
     array.set(2, 6);
 
-    assert.deepEqual(take(array.keys()), [0, 1, 2]);
+    assert.deepStrictEqual(take(array.keys()), [0, 1, 2]);
   });
 });

--- a/test/multi-map.js
+++ b/test/multi-map.js
@@ -59,19 +59,19 @@ describe('MultiMap', function() {
 
     map.remove('one', 1);
 
-    assert.deepEqual(map.get('one'), [2, 1]);
+    assert.deepStrictEqual(map.get('one'), [2, 1]);
     assert.strictEqual(map.size, 2);
     assert.strictEqual(map.dimension, 1);
 
     map.remove('one', 1);
 
-    assert.deepEqual(map.get('one'), [2]);
+    assert.deepStrictEqual(map.get('one'), [2]);
     assert.strictEqual(map.size, 1);
     assert.strictEqual(map.dimension, 1);
 
     map.remove('one', 1);
 
-    assert.deepEqual(map.get('one'), [2]);
+    assert.deepStrictEqual(map.get('one'), [2]);
     assert.strictEqual(map.size, 1);
     assert.strictEqual(map.dimension, 1);
 
@@ -89,7 +89,7 @@ describe('MultiMap', function() {
 
     map.remove('one', 1);
 
-    assert.deepEqual(Array.from(map.get('one')), [2]);
+    assert.deepStrictEqual(Array.from(map.get('one')), [2]);
     assert.strictEqual(map.size, 1);
     assert.strictEqual(map.dimension, 1);
 
@@ -133,7 +133,7 @@ describe('MultiMap', function() {
     map.set('one', 'hello');
     map.set('one', 'world');
 
-    assert.deepEqual(map.get('one'), [
+    assert.deepStrictEqual(map.get('one'), [
       'hello',
       'world'
     ]);
@@ -147,7 +147,7 @@ describe('MultiMap', function() {
     assert.strictEqual(map.size, 2);
 
     assert.strictEqual(map.get('one') instanceof Set, true);
-    assert.deepEqual(Array.from(map.get('one')), [
+    assert.deepStrictEqual(Array.from(map.get('one')), [
       'hello',
       'world'
     ]);
@@ -184,7 +184,7 @@ describe('MultiMap', function() {
       entries.push([key, container]);
     });
 
-    assert.deepEqual(entries, [
+    assert.deepStrictEqual(entries, [
       ['one', ['hello', 'world']],
       ['two', ['hello']]
     ]);
@@ -248,9 +248,9 @@ describe('MultiMap', function() {
 
     var iterator = map.entries();
 
-    assert.deepEqual(iterator.next().value, ['one', 'hello']);
-    assert.deepEqual(iterator.next().value, ['one', 'world']);
-    assert.deepEqual(iterator.next().value, ['two', 'hello']);
+    assert.deepStrictEqual(iterator.next().value, ['one', 'hello']);
+    assert.deepStrictEqual(iterator.next().value, ['one', 'world']);
+    assert.deepStrictEqual(iterator.next().value, ['two', 'hello']);
     assert.strictEqual(iterator.next().done, true);
 
     assert.deepStrictEqual([...map.entries()], [['one', 'hello'], ['one', 'world'], ['two', 'hello']]);
@@ -263,9 +263,9 @@ describe('MultiMap', function() {
 
     iterator = map.entries();
 
-    assert.deepEqual(iterator.next().value, ['one', 'hello']);
-    assert.deepEqual(iterator.next().value, ['one', 'world']);
-    assert.deepEqual(iterator.next().value, ['two', 'hello']);
+    assert.deepStrictEqual(iterator.next().value, ['one', 'hello']);
+    assert.deepStrictEqual(iterator.next().value, ['one', 'world']);
+    assert.deepStrictEqual(iterator.next().value, ['two', 'hello']);
     assert.strictEqual(iterator.next().done, true);
 
     assert.deepStrictEqual([...map.entries()], [['one', 'hello'], ['one', 'world'], ['two', 'hello']]);
@@ -281,8 +281,8 @@ describe('MultiMap', function() {
 
     var iterator = map.containers();
 
-    assert.deepEqual(iterator.next().value, new Set(['hello', 'world']));
-    assert.deepEqual(iterator.next().value, new Set(['hello']));
+    assert.deepStrictEqual(iterator.next().value, new Set(['hello', 'world']));
+    assert.deepStrictEqual(iterator.next().value, new Set(['hello']));
     assert.strictEqual(iterator.next().done, true);
 
     assert.deepStrictEqual([...map.containers()], [new Set(['hello', 'world']), new Set(['hello'])]);
@@ -295,8 +295,8 @@ describe('MultiMap', function() {
 
     iterator = map.containers();
 
-    assert.deepEqual(iterator.next().value, ['hello', 'world']);
-    assert.deepEqual(iterator.next().value, ['hello']);
+    assert.deepStrictEqual(iterator.next().value, ['hello', 'world']);
+    assert.deepStrictEqual(iterator.next().value, ['hello']);
     assert.strictEqual(iterator.next().done, true);
 
     assert.deepStrictEqual([...map.containers()], [['hello', 'world'], ['hello']]);
@@ -312,8 +312,8 @@ describe('MultiMap', function() {
 
     var iterator = map.associations();
 
-    assert.deepEqual(iterator.next().value, ['one', new Set(['hello', 'world'])]);
-    assert.deepEqual(iterator.next().value, ['two', new Set(['hello'])]);
+    assert.deepStrictEqual(iterator.next().value, ['one', new Set(['hello', 'world'])]);
+    assert.deepStrictEqual(iterator.next().value, ['two', new Set(['hello'])]);
     assert.strictEqual(iterator.next().done, true);
 
     assert.deepStrictEqual(
@@ -329,8 +329,8 @@ describe('MultiMap', function() {
 
     iterator = map.associations();
 
-    assert.deepEqual(iterator.next().value, ['one', ['hello', 'world']]);
-    assert.deepEqual(iterator.next().value, ['two', ['hello']]);
+    assert.deepStrictEqual(iterator.next().value, ['one', ['hello', 'world']]);
+    assert.deepStrictEqual(iterator.next().value, ['two', ['hello']]);
     assert.strictEqual(iterator.next().done, true);
 
     assert.deepStrictEqual(
@@ -364,7 +364,7 @@ describe('MultiMap', function() {
 
     assert.strictEqual(map.size, 2);
     assert.strictEqual(map.dimension, 2);
-    assert.deepEqual(map.get('one'), ['hello']);
+    assert.deepStrictEqual(map.get('one'), ['hello']);
   });
 
   it('should work with vectors.', function() {
@@ -376,6 +376,6 @@ describe('MultiMap', function() {
 
     assert.strictEqual(map.size, 3);
     assert.strictEqual(map.dimension, 2);
-    assert.deepEqual(Array.from(map.get('one')), [45, 9]);
+    assert.deepStrictEqual(Array.from(map.get('one')), [45, 9]);
   });
 });

--- a/test/multi-set.js
+++ b/test/multi-set.js
@@ -173,12 +173,12 @@ describe('MultiSet', function() {
     set.add('a');
     set.edit('a', 'b');
 
-    assert.deepEqual(Array.from(set.multiplicities()), [['b', 1]]);
+    assert.deepStrictEqual(Array.from(set.multiplicities()), [['b', 1]]);
 
     set.add('c');
     set.edit('b', 'c');
 
-    assert.deepEqual(Array.from(set.multiplicities()), [['c', 2]]);
+    assert.deepStrictEqual(Array.from(set.multiplicities()), [['c', 2]]);
   });
 
   it('should be possible to iterate over a set.', function() {
@@ -209,7 +209,7 @@ describe('MultiSet', function() {
       entries.push([key, value]);
     });
 
-    assert.deepEqual(entries, [
+    assert.deepStrictEqual(entries, [
       ['hello', 4],
       ['world', 3]
     ]);
@@ -249,8 +249,8 @@ describe('MultiSet', function() {
 
     var iterator = set.multiplicities();
 
-    assert.deepEqual(iterator.next().value, ['hello', 2]);
-    assert.deepEqual(iterator.next().value, ['world', 1]);
+    assert.deepStrictEqual(iterator.next().value, ['hello', 2]);
+    assert.deepStrictEqual(iterator.next().value, ['world', 1]);
     assert.strictEqual(iterator.next().done, true);
   });
 
@@ -304,11 +304,11 @@ describe('MultiSet', function() {
 
     var top5 = set.top(5);
 
-    assert.deepEqual(top5, [['i', 7], [' ', 7], ['r', 4], ['e', 4], ['s', 4]]);
+    assert.deepStrictEqual(top5, [['i', 7], [' ', 7], ['r', 4], ['e', 4], ['s', 4]]);
 
     var top = set.top(1);
 
-    assert.deepEqual(top, [['i', 7]]);
+    assert.deepStrictEqual(top, [['i', 7]]);
   });
 
   describe('helpers', function() {

--- a/test/passjoin-index.js
+++ b/test/passjoin-index.js
@@ -102,12 +102,12 @@ describe('PassjoinIndex', function() {
 
     var sorted = strings.slice().sort(PassjoinIndex.comparator);
 
-    assert.deepEqual(sorted, ['abcde', 'aba', 'abc', 'a']);
+    assert.deepStrictEqual(sorted, ['abcde', 'aba', 'abc', 'a']);
   });
 
   it('should be possible to split strings into segments for indexation.', function() {
-    assert.deepEqual(PassjoinIndex.segments(3, 'vankatesh'), ['va', 'nk', 'at', 'esh']);
-    assert.deepEqual(PassjoinIndex.segments(3, 'avaterasha'), ['av', 'at', 'era', 'sha']);
+    assert.deepStrictEqual(PassjoinIndex.segments(3, 'vankatesh'), ['va', 'nk', 'at', 'esh']);
+    assert.deepStrictEqual(PassjoinIndex.segments(3, 'avaterasha'), ['av', 'at', 'era', 'sha']);
   });
 
   it('should be possible to retrieve a segment\'s position.', function() {
@@ -132,7 +132,7 @@ describe('PassjoinIndex', function() {
           pi = params[2],
           li = params[3];
 
-      assert.deepEqual(
+      assert.deepStrictEqual(
         PassjoinIndex.multiMatchAwareInterval(3, delta, i, 10, pi, li),
         interval
       );
@@ -151,7 +151,7 @@ describe('PassjoinIndex', function() {
         var pi = P[j][0],
             li = P[j][1];
 
-        assert.deepEqual(
+        assert.deepStrictEqual(
           PassjoinIndex.multiMatchAwareSubstrings(3, 'avaterasha', l, i, pi, li),
           substrings
         );
@@ -161,7 +161,7 @@ describe('PassjoinIndex', function() {
     // Duplicate letters
     var substringsWithoutDuplicates = PassjoinIndex.multiMatchAwareSubstrings(3, 'avatssssha', 11, 2, 5, 3);
 
-    assert.deepEqual(substringsWithoutDuplicates, ['tss', 'sss']);
+    assert.deepStrictEqual(substringsWithoutDuplicates, ['tss', 'sss']);
   });
 
   it('should throw if given wrong arguments.', function() {
@@ -188,14 +188,14 @@ describe('PassjoinIndex', function() {
     assert.strictEqual(k1.size, STRINGS.length);
     assert.strict(k1.k, 1);
 
-    assert.deepEqual(k1.search('paul'), new Set(['paul', 'paule']));
-    assert.deepEqual(k1.search('paulet'), new Set(['paule']));
-    assert.deepEqual(k1.search('a'), new Set(['', 'a', 'b', 'pa', 'ab']));
+    assert.deepStrictEqual(k1.search('paul'), new Set(['paul', 'paule']));
+    assert.deepStrictEqual(k1.search('paulet'), new Set(['paule']));
+    assert.deepStrictEqual(k1.search('a'), new Set(['', 'a', 'b', 'pa', 'ab']));
 
-    assert.deepEqual(k2.search('benjiman'), new Set(['benjamin', 'benjomon']));
+    assert.deepStrictEqual(k2.search('benjiman'), new Set(['benjamin', 'benjomon']));
 
-    assert.deepEqual(k3.search('benja'), new Set(['benjamin', 'benja']));
-    assert.deepEqual(k3.search('pa'), new Set(['', 'a', 'b', 'pa', 'ab', 'paul', 'paule']));
+    assert.deepStrictEqual(k3.search('benja'), new Set(['benjamin', 'benja']));
+    assert.deepStrictEqual(k3.search('pa'), new Set(['', 'a', 'b', 'pa', 'ab', 'paul', 'paule']));
   });
 
   it('should remain sane.', function() {
@@ -208,18 +208,18 @@ describe('PassjoinIndex', function() {
 
     var results = index.search('agility\'s');
 
-    assert.deepEqual(results, new Set(['agility\'s', 'ability\'s']));
+    assert.deepStrictEqual(results, new Set(['agility\'s', 'ability\'s']));
 
     results = index.search('failed');
 
-    assert.deepEqual(results, new Set(['failed', 'flailed']));
+    assert.deepStrictEqual(results, new Set(['failed', 'flailed']));
   });
 
   it('should be possible to create an index from an arbitrary index.', function() {
     var index = PassjoinIndex.from(['failed', 'flailed'], leven, 1);
 
     assert.strictEqual(index.size, 2);
-    assert.deepEqual(index.search('failed'), new Set(['failed', 'flailed']));
+    assert.deepStrictEqual(index.search('failed'), new Set(['failed', 'flailed']));
   });
 
   it('should be possible to iterate over the index.', function() {
@@ -241,7 +241,7 @@ describe('PassjoinIndex', function() {
 
     var index = PassjoinIndex.from(['a', 'ab', 'abc'], leven, 1);
 
-    assert.deepEqual(Array.from(index.values()), strings);
+    assert.deepStrictEqual(Array.from(index.values()), strings);
   });
 
   it('should be possible to iterate over the index using for...of.', function() {
@@ -264,7 +264,7 @@ describe('PassjoinIndex', function() {
     index.clear();
 
     assert.strictEqual(index.size, 0);
-    assert.deepEqual(Array.from(index.values()), []);
-    assert.deepEqual(index.search('abc'), new Set());
+    assert.deepStrictEqual(Array.from(index.values()), []);
+    assert.deepStrictEqual(index.search('abc'), new Set());
   });
 });

--- a/test/queue.js
+++ b/test/queue.js
@@ -24,7 +24,7 @@ describe('Queue', function() {
     queue.clear();
 
     assert.strictEqual(queue.size, 0);
-    assert.deepEqual(queue.toArray(), []);
+    assert.deepStrictEqual(queue.toArray(), []);
   });
 
   it('should be possible to peek.', function() {
@@ -79,19 +79,19 @@ describe('Queue', function() {
     queue.enqueue(2);
     queue.enqueue(3);
 
-    assert.deepEqual(queue.toArray(), [1, 2, 3]);
+    assert.deepStrictEqual(queue.toArray(), [1, 2, 3]);
   });
 
   it('should be possible to create a queue from an arbitrary iterable.', function() {
     var queue = Queue.from([1, 2, 3]);
 
-    assert.deepEqual(queue.toArray(), [1, 2, 3]);
+    assert.deepStrictEqual(queue.toArray(), [1, 2, 3]);
   });
 
   it('should be possible to create a queue from arbitrary arguments.', function() {
     var queue = Queue.of(1, 2, 3);
 
-    assert.deepEqual(queue.toArray(), [1, 2, 3]);
+    assert.deepStrictEqual(queue.toArray(), [1, 2, 3]);
   });
 
   it('should be possible to create a values iterator.', function() {
@@ -110,9 +110,9 @@ describe('Queue', function() {
 
     var iterator = queue.entries();
 
-    assert.deepEqual(iterator.next().value, [0, 1]);
-    assert.deepEqual(iterator.next().value, [1, 2]);
-    assert.deepEqual(iterator.next().value, [2, 3]);
+    assert.deepStrictEqual(iterator.next().value, [0, 1]);
+    assert.deepStrictEqual(iterator.next().value, [1, 2]);
+    assert.deepStrictEqual(iterator.next().value, [2, 3]);
     assert.strictEqual(iterator.next().done, true);
   });
 

--- a/test/set.js
+++ b/test/set.js
@@ -16,7 +16,7 @@ describe('Set functions', function() {
 
       var I = functions.intersection(A, B);
 
-      assert.deepEqual(Array.from(I), [2, 3]);
+      assert.deepStrictEqual(Array.from(I), [2, 3]);
     });
 
     it('should be variadic.', function() {
@@ -27,7 +27,7 @@ describe('Set functions', function() {
 
       var I = functions.intersection(A, B, C, D);
 
-      assert.deepEqual(Array.from(I), [4]);
+      assert.deepStrictEqual(Array.from(I), [4]);
     });
   });
 
@@ -39,7 +39,7 @@ describe('Set functions', function() {
 
       var U = functions.union(A, B);
 
-      assert.deepEqual(Array.from(U), [1, 2, 3, 4]);
+      assert.deepStrictEqual(Array.from(U), [1, 2, 3, 4]);
     });
 
     it('should be variadic.', function() {
@@ -50,7 +50,7 @@ describe('Set functions', function() {
 
       var U = functions.union(A, B, C, D);
 
-      assert.deepEqual(Array.from(U), [1, 2, 3, 4, 5, 6]);
+      assert.deepStrictEqual(Array.from(U), [1, 2, 3, 4, 5, 6]);
     });
   });
 
@@ -62,7 +62,7 @@ describe('Set functions', function() {
 
       var D = functions.difference(A, B);
 
-      assert.deepEqual(Array.from(D), [1, 4, 5]);
+      assert.deepStrictEqual(Array.from(D), [1, 4, 5]);
     });
   });
 
@@ -74,7 +74,7 @@ describe('Set functions', function() {
 
       var S = functions.symmetricDifference(A, B);
 
-      assert.deepEqual(Array.from(S), [1, 2, 4, 5]);
+      assert.deepStrictEqual(Array.from(S), [1, 2, 4, 5]);
     });
   });
 
@@ -106,7 +106,7 @@ describe('Set functions', function() {
 
       functions.add(A, new Set([2, 3]));
 
-      assert.deepEqual(Array.from(A), [1, 2, 3]);
+      assert.deepStrictEqual(Array.from(A), [1, 2, 3]);
     });
   });
 
@@ -116,7 +116,7 @@ describe('Set functions', function() {
 
       functions.subtract(A, new Set([2, 3]));
 
-      assert.deepEqual(Array.from(A), [1]);
+      assert.deepStrictEqual(Array.from(A), [1]);
     });
   });
 
@@ -126,7 +126,7 @@ describe('Set functions', function() {
 
       functions.intersect(A, new Set([2, 3]));
 
-      assert.deepEqual(Array.from(A), [2]);
+      assert.deepStrictEqual(Array.from(A), [2]);
     });
   });
 
@@ -136,7 +136,7 @@ describe('Set functions', function() {
 
       functions.disjunct(A, new Set([2, 3]));
 
-      assert.deepEqual(Array.from(A), [1, 3]);
+      assert.deepStrictEqual(Array.from(A), [1, 3]);
     });
   });
 

--- a/test/sort.js
+++ b/test/sort.js
@@ -35,31 +35,31 @@ describe('Sort helpers', function() {
 
       var data = insertion.inplaceInsertionSort(DATA.slice(), 0, DATA.length);
 
-      assert.deepEqual(data, [-3, 1, 1, 2, 3, 5, 6, 7, 8, 9, 18]);
+      assert.deepStrictEqual(data, [-3, 1, 1, 2, 3, 5, 6, 7, 8, 9, 18]);
     });
 
     it('should work with edge cases.', function() {
       var data = insertion.inplaceInsertionSort([1], 0, 1);
 
-      assert.deepEqual(data, [1]);
+      assert.deepStrictEqual(data, [1]);
 
       data = insertion.inplaceInsertionSort([2, 1], 0, 2);
 
-      assert.deepEqual(data, [1, 2]);
+      assert.deepStrictEqual(data, [1, 2]);
     });
 
     it('should properly sort only a slice.', function() {
       var data = insertion.inplaceInsertionSort(DATA.slice(), 0, 3);
 
-      assert.deepEqual(data, [1, 2, 7, 5, 8, 9, 1, -3, 3, 18, 6]);
+      assert.deepStrictEqual(data, [1, 2, 7, 5, 8, 9, 1, -3, 3, 18, 6]);
 
       data = insertion.inplaceInsertionSort(DATA.slice(), 3, 7);
 
-      assert.deepEqual(data, [2, 7, 1, 1, 5, 8, 9, -3, 3, 18, 6]);
+      assert.deepStrictEqual(data, [2, 7, 1, 1, 5, 8, 9, -3, 3, 18, 6]);
 
       data = insertion.inplaceInsertionSort(DATA.slice(), 5, 11);
 
-      assert.deepEqual(data, [2, 7, 1, 5, 8, -3, 1, 3, 6, 9, 18]);
+      assert.deepStrictEqual(data, [2, 7, 1, 5, 8, -3, 1, 3, 6, 9, 18]);
     });
 
     it('sanity test.', function() {
@@ -76,21 +76,21 @@ describe('Sort helpers', function() {
 
       var indices = insertion.inplaceInsertionSortIndices(DATA.slice(), typed.indices(DATA.length), 0, DATA.length);
 
-      assert.deepEqual(Array.from(indices), [7, 2, 6, 0, 8, 3, 10, 1, 4, 5, 9]);
+      assert.deepStrictEqual(Array.from(indices), [7, 2, 6, 0, 8, 3, 10, 1, 4, 5, 9]);
     });
 
     it('should properly sort only a slice of indices.', function() {
       var indices = insertion.inplaceInsertionSortIndices(DATA.slice(), typed.indices(DATA.length), 0, 3);
 
-      assert.deepEqual(Array.from(indices), [2, 0, 1, 3, 4, 5, 6, 7, 8, 9, 10]);
+      assert.deepStrictEqual(Array.from(indices), [2, 0, 1, 3, 4, 5, 6, 7, 8, 9, 10]);
 
       indices = insertion.inplaceInsertionSortIndices(DATA.slice(), typed.indices(DATA.length), 3, 7);
 
-      assert.deepEqual(Array.from(indices), [0, 1, 2, 6, 3, 4, 5, 7, 8, 9, 10]);
+      assert.deepStrictEqual(Array.from(indices), [0, 1, 2, 6, 3, 4, 5, 7, 8, 9, 10]);
 
       indices = insertion.inplaceInsertionSortIndices(DATA.slice(), typed.indices(DATA.length), 5, 11);
 
-      assert.deepEqual(Array.from(indices), [0, 1, 2, 3, 4, 7, 6, 8, 10, 5, 9]);
+      assert.deepStrictEqual(Array.from(indices), [0, 1, 2, 3, 4, 7, 6, 8, 10, 5, 9]);
     });
 
     it('indices sanity test.', function() {
@@ -109,21 +109,21 @@ describe('Sort helpers', function() {
 
       var data = quick.inplaceQuickSort(DATA.slice(), 0, DATA.length);
 
-      assert.deepEqual(data, [-3, 1, 1, 2, 3, 5, 6, 7, 8, 9, 18]);
+      assert.deepStrictEqual(data, [-3, 1, 1, 2, 3, 5, 6, 7, 8, 9, 18]);
     });
 
     it('should properly sort only a slice.', function() {
       var data = quick.inplaceQuickSort(DATA.slice(), 0, 3);
 
-      assert.deepEqual(data, [1, 2, 7, 5, 8, 9, 1, -3, 3, 18, 6]);
+      assert.deepStrictEqual(data, [1, 2, 7, 5, 8, 9, 1, -3, 3, 18, 6]);
 
       data = quick.inplaceQuickSort(DATA.slice(), 3, 7);
 
-      assert.deepEqual(data, [2, 7, 1, 1, 5, 8, 9, -3, 3, 18, 6]);
+      assert.deepStrictEqual(data, [2, 7, 1, 1, 5, 8, 9, -3, 3, 18, 6]);
 
       data = quick.inplaceQuickSort(DATA.slice(), 5, 11);
 
-      assert.deepEqual(data, [2, 7, 1, 5, 8, -3, 1, 3, 6, 9, 18]);
+      assert.deepStrictEqual(data, [2, 7, 1, 5, 8, -3, 1, 3, 6, 9, 18]);
     });
 
     it('sanity test.', function() {
@@ -140,21 +140,21 @@ describe('Sort helpers', function() {
 
       var indices = quick.inplaceQuickSortIndices(DATA.slice(), typed.indices(DATA.length), 0, DATA.length);
 
-      assert.deepEqual(Array.from(indices), [7, 6, 2, 0, 8, 3, 10, 1, 4, 5, 9]);
+      assert.deepStrictEqual(Array.from(indices), [7, 6, 2, 0, 8, 3, 10, 1, 4, 5, 9]);
     });
 
     it('should properly sort only a slice of indices.', function() {
       var indices = quick.inplaceQuickSortIndices(DATA.slice(), typed.indices(DATA.length), 0, 3);
 
-      assert.deepEqual(Array.from(indices), [2, 0, 1, 3, 4, 5, 6, 7, 8, 9, 10]);
+      assert.deepStrictEqual(Array.from(indices), [2, 0, 1, 3, 4, 5, 6, 7, 8, 9, 10]);
 
       indices = quick.inplaceQuickSortIndices(DATA.slice(), typed.indices(DATA.length), 3, 7);
 
-      assert.deepEqual(Array.from(indices), [0, 1, 2, 6, 3, 4, 5, 7, 8, 9, 10]);
+      assert.deepStrictEqual(Array.from(indices), [0, 1, 2, 6, 3, 4, 5, 7, 8, 9, 10]);
 
       indices = quick.inplaceQuickSortIndices(DATA.slice(), typed.indices(DATA.length), 5, 11);
 
-      assert.deepEqual(Array.from(indices), [0, 1, 2, 3, 4, 7, 6, 8, 10, 5, 9]);
+      assert.deepStrictEqual(Array.from(indices), [0, 1, 2, 3, 4, 7, 6, 8, 10, 5, 9]);
     });
 
     it('indices sanity test.', function() {

--- a/test/sparse-map.js
+++ b/test/sparse-map.js
@@ -103,7 +103,7 @@ describe('SparseMap', function() {
         i = 0;
 
     map.forEach(function(value, key) {
-      assert.deepEqual([key, value], array[i++]);
+      assert.deepStrictEqual([key, value], array[i++]);
     });
   });
 
@@ -114,7 +114,7 @@ describe('SparseMap', function() {
     map.set(6, 22);
     map.set(9, 8);
 
-    assert.deepEqual(obliterator.take(map.keys()), [3, 6, 9]);
+    assert.deepStrictEqual(obliterator.take(map.keys()), [3, 6, 9]);
   });
 
   it('should be possible to create an iterator over the map\'s values.', function() {
@@ -124,7 +124,7 @@ describe('SparseMap', function() {
     map.set(6, 22);
     map.set(9, 8);
 
-    assert.deepEqual(obliterator.take(map.values()), [13, 22, 8]);
+    assert.deepStrictEqual(obliterator.take(map.values()), [13, 22, 8]);
   });
 
   it('should be possible to create an iterator over the map\'s entries.', function() {
@@ -134,6 +134,6 @@ describe('SparseMap', function() {
     map.set(6, 22);
     map.set(9, 8);
 
-    assert.deepEqual(obliterator.take(map.entries()), [[3, 13], [6, 22], [9, 8]]);
+    assert.deepStrictEqual(obliterator.take(map.entries()), [[3, 13], [6, 22], [9, 8]]);
   });
 });

--- a/test/sparse-queue-set.js
+++ b/test/sparse-queue-set.js
@@ -74,7 +74,7 @@ describe('SparseQueueSet', function() {
         assert.strictEqual(queue.size, i + 1);
       });
 
-      assert.deepEqual(obliterator.take(queue.values()), values);
+      assert.deepStrictEqual(obliterator.take(queue.values()), values);
 
       var contained = [];
 
@@ -82,7 +82,7 @@ describe('SparseQueueSet', function() {
         contained.push(v);
       });
 
-      assert.deepEqual(contained, values);
+      assert.deepStrictEqual(contained, values);
 
       values.forEach(function(v, i) {
         assert.strictEqual(queue.has(v), true);
@@ -104,7 +104,7 @@ describe('SparseQueueSet', function() {
     queue.enqueue(0);
     queue.enqueue(1);
 
-    assert.deepEqual(obliterator.take(queue.values()), [0, 1, 2, 3]);
+    assert.deepStrictEqual(obliterator.take(queue.values()), [0, 1, 2, 3]);
   });
 
   it('should be possible to iterate over the queue\'s items.', function() {
@@ -129,6 +129,6 @@ describe('SparseQueueSet', function() {
     queue.enqueue(6);
     queue.enqueue(9);
 
-    assert.deepEqual(obliterator.take(queue.values()), [3, 6, 9]);
+    assert.deepStrictEqual(obliterator.take(queue.values()), [3, 6, 9]);
   });
 });

--- a/test/sparse-set.js
+++ b/test/sparse-set.js
@@ -71,6 +71,6 @@ describe('SparseSet', function() {
     set.add(6);
     set.add(9);
 
-    assert.deepEqual(obliterator.take(set.values()), [3, 6, 9]);
+    assert.deepStrictEqual(obliterator.take(set.values()), [3, 6, 9]);
   });
 });

--- a/test/stack.js
+++ b/test/stack.js
@@ -24,7 +24,7 @@ describe('Stack', function() {
     stack.clear();
 
     assert.strictEqual(stack.size, 0);
-    assert.deepEqual(stack.toArray(), []);
+    assert.deepStrictEqual(stack.toArray(), []);
   });
 
   it('should be possible to peek.', function() {
@@ -79,19 +79,19 @@ describe('Stack', function() {
     stack.push(2);
     stack.push(3);
 
-    assert.deepEqual(stack.toArray(), [3, 2, 1]);
+    assert.deepStrictEqual(stack.toArray(), [3, 2, 1]);
   });
 
   it('should be possible to create a stack from an arbitrary iterable.', function() {
     var stack = Stack.from([1, 2, 3]);
 
-    assert.deepEqual(stack.toArray(), [3, 2, 1]);
+    assert.deepStrictEqual(stack.toArray(), [3, 2, 1]);
   });
 
   it('should be possible to create a stack from arbitrary arguments.', function() {
     var stack = Stack.of(1, 2, 3);
 
-    assert.deepEqual(stack.toArray(), [3, 2, 1]);
+    assert.deepStrictEqual(stack.toArray(), [3, 2, 1]);
   });
 
   it('should be possible to create a values iterator.', function() {
@@ -110,9 +110,9 @@ describe('Stack', function() {
 
     var iterator = stack.entries();
 
-    assert.deepEqual(iterator.next().value, [0, 3]);
-    assert.deepEqual(iterator.next().value, [1, 2]);
-    assert.deepEqual(iterator.next().value, [2, 1]);
+    assert.deepStrictEqual(iterator.next().value, [0, 3]);
+    assert.deepStrictEqual(iterator.next().value, [1, 2]);
+    assert.deepStrictEqual(iterator.next().value, [2, 1]);
     assert.strictEqual(iterator.next().done, true);
   });
 

--- a/test/static-disjoint-set.js
+++ b/test/static-disjoint-set.js
@@ -26,9 +26,9 @@ describe('StaticDisjointSet', function() {
 
     var mapping = sets.mapping();
 
-    assert.deepEqual(Array.from(mapping), [0, 0, 1, 1, 1, 0, 2, 0, 3, 3]);
+    assert.deepStrictEqual(Array.from(mapping), [0, 0, 1, 1, 1, 0, 2, 0, 3, 3]);
 
     var compiled = sets.compile();
-    assert.deepEqual(Array.from(compiled, a => Array.from(a)), [[0, 1, 5, 7], [2, 3, 4], [6], [8, 9]]);
+    assert.deepStrictEqual(Array.from(compiled, a => Array.from(a)), [[0, 1, 5, 7], [2, 3, 4], [6], [8, 9]]);
   });
 });

--- a/test/static-interval-tree.js
+++ b/test/static-interval-tree.js
@@ -42,23 +42,23 @@ describe('StaticIntervalTree', function() {
 
     var intervals = tree.intervalsContainingPoint(134);
 
-    assert.deepEqual(intervals, []);
+    assert.deepStrictEqual(intervals, []);
 
     intervals = tree.intervalsContainingPoint(13);
 
-    assert.deepEqual(intervals, [[10, 15], [3, 41]]);
+    assert.deepStrictEqual(intervals, [[10, 15], [3, 41]]);
 
     intervals = tree.intervalsContainingPoint(0);
 
-    assert.deepEqual(intervals, [[0, 1]]);
+    assert.deepStrictEqual(intervals, [[0, 1]]);
 
     intervals = tree.intervalsContainingPoint(4);
 
-    assert.deepEqual(intervals, [[3, 41]]);
+    assert.deepStrictEqual(intervals, [[3, 41]]);
 
     intervals = tree.intervalsContainingPoint(25);
 
-    assert.deepEqual(intervals, [[20, 36], [3, 41]]);
+    assert.deepStrictEqual(intervals, [[20, 36], [3, 41]]);
   });
 
   it('should be possible to query by interval.', function() {
@@ -66,11 +66,11 @@ describe('StaticIntervalTree', function() {
 
     var intervals = tree.intervalsOverlappingInterval([-34, 4]);
 
-    assert.deepEqual(intervals, [[0, 1], [3, 41]]);
+    assert.deepStrictEqual(intervals, [[0, 1], [3, 41]]);
 
     intervals = tree.intervalsOverlappingInterval([-100, 100]);
 
-    assert.deepEqual(intervals, [[10, 15], [20, 36], [29, 99], [0, 1], [3, 41]]);
+    assert.deepStrictEqual(intervals, [[10, 15], [20, 36], [29, 99], [0, 1], [3, 41]]);
   });
 
   it('should be possible to use getters.', function() {
@@ -86,10 +86,10 @@ describe('StaticIntervalTree', function() {
 
     var intervals = tree.intervalsContainingPoint(0);
 
-    assert.deepEqual(intervals, [{start: 0, end: 1}]);
+    assert.deepStrictEqual(intervals, [{start: 0, end: 1}]);
 
     intervals = tree.intervalsOverlappingInterval({start: -34, end: 4});
 
-    assert.deepEqual(intervals, [{start: 0, end: 1}, {start: 3, end: 41}]);
+    assert.deepStrictEqual(intervals, [{start: 0, end: 1}, {start: 3, end: 41}]);
   });
 });

--- a/test/suffix-array.js
+++ b/test/suffix-array.js
@@ -14,11 +14,11 @@ describe('SuffixArray', function() {
 
     assert.strictEqual(sa.length, 6);
     assert.strictEqual(sa.string, 'banana');
-    assert.deepEqual(sa.array, [5, 3, 1, 0, 4, 2]);
+    assert.deepStrictEqual(sa.array, [5, 3, 1, 0, 4, 2]);
 
     sa = new SuffixArray('This is a long string.');
 
-    assert.deepEqual(
+    assert.deepStrictEqual(
       sa.array,
       [
         7, 4, 9,
@@ -37,8 +37,8 @@ describe('SuffixArray', function() {
     var sa = new SuffixArray('banana'.split(''));
 
     assert.strictEqual(sa.length, 6);
-    assert.deepEqual(sa.string, 'banana'.split(''));
-    assert.deepEqual(sa.array, [5, 3, 1, 0, 4, 2]);
+    assert.deepStrictEqual(sa.string, 'banana'.split(''));
+    assert.deepStrictEqual(sa.array, [5, 3, 1, 0, 4, 2]);
   });
 });
 
@@ -49,7 +49,7 @@ describe('GeneralizedSuffixArray', function() {
 
     assert.strictEqual(sa.length, 13);
     assert.strictEqual(sa.size, 2);
-    assert.deepEqual(sa.array, [6, 5, 3, 1, 7, 9, 11, 0, 4, 2, 8, 10, 12]);
+    assert.deepStrictEqual(sa.array, [6, 5, 3, 1, 7, 9, 11, 0, 4, 2, 8, 10, 12]);
   });
 
   it('should also work with arbitrary sequences.', function() {
@@ -59,7 +59,7 @@ describe('GeneralizedSuffixArray', function() {
 
     assert.strictEqual(sa.length, 13);
     assert.strictEqual(sa.size, 2);
-    assert.deepEqual(sa.array, [6, 5, 3, 1, 7, 9, 11, 0, 4, 2, 8, 10, 12]);
+    assert.deepStrictEqual(sa.array, [6, 5, 3, 1, 7, 9, 11, 0, 4, 2, 8, 10, 12]);
   });
 
   it('should be possible to extract the longest common subsequence.', function() {
@@ -82,7 +82,7 @@ describe('GeneralizedSuffixArray', function() {
       ['the', 'mouse', 'eats', 'cheese']
     ]);
 
-    assert.deepEqual(
+    assert.deepStrictEqual(
       sa.longestCommonSubsequence(),
       ['the', 'mouse']
     );

--- a/test/symspell.js
+++ b/test/symspell.js
@@ -39,12 +39,12 @@ describe('SymSpell', function() {
 
     assert.strictEqual(index.size, 10);
 
-    assert.deepEqual(
+    assert.deepStrictEqual(
       index.search('shawarma'),
       []
     );
 
-    assert.deepEqual(
+    assert.deepStrictEqual(
       index.search('ello'),
       [
         {term: 'Hello', distance: 1, count: 2},
@@ -67,7 +67,7 @@ describe('SymSpell', function() {
     var index = new SymSpell({maxDistance: 4});
     DATA.forEach(word => index.add(word));
 
-    assert.deepEqual(
+    assert.deepStrictEqual(
       index.search('ello'),
       [
         {term: 'Hello', distance: 1, count: 2},
@@ -91,12 +91,12 @@ describe('SymSpell', function() {
       lessLazyIndex.add(word);
     });
 
-    assert.deepEqual(
+    assert.deepStrictEqual(
       lazyIndex.search('ello'),
       [{term: 'Hello', distance: 1, count: 2}]
     );
 
-    assert.deepEqual(
+    assert.deepStrictEqual(
       lessLazyIndex.search('ello'),
       [
         {term: 'Hello', distance: 1, count: 2},
@@ -117,7 +117,7 @@ describe('SymSpell', function() {
   it('should be possible to create an index from arbitrary iterables.', function() {
     var index = SymSpell.from(DATA);
 
-    assert.deepEqual(
+    assert.deepStrictEqual(
       index.search('ello'),
       [
         {term: 'Hello', distance: 1, count: 2},

--- a/test/trie-map.js
+++ b/test/trie-map.js
@@ -32,7 +32,7 @@ describe('TrieMap', function() {
     assert.strictEqual(trie.get('ra'), undefined);
     assert.strictEqual(trie.get('ratings'), undefined);
 
-    assert.deepEqual(trie.root, {
+    assert.deepStrictEqual(trie.root, {
       r: {
         a: {
           t: {
@@ -105,7 +105,7 @@ describe('TrieMap', function() {
 
     assert.strictEqual(trie.size, 2);
 
-    assert.deepEqual(trie.root, {
+    assert.deepStrictEqual(trie.root, {
       r: {
         a: {
           t: {
@@ -128,7 +128,7 @@ describe('TrieMap', function() {
 
     assert.strictEqual(trie.size, 1);
 
-    assert.deepEqual(trie.root, {
+    assert.deepStrictEqual(trie.root, {
       t: {
         a: {
           r: {
@@ -142,7 +142,7 @@ describe('TrieMap', function() {
 
     assert.strictEqual(trie.size, 0);
 
-    assert.deepEqual(trie.root, {});
+    assert.deepStrictEqual(trie.root, {});
   });
 
   it('should be possible to check the existence of a sequence in the TrieMap.', function() {
@@ -164,12 +164,12 @@ describe('TrieMap', function() {
     trie.set('romanesques', 3);
     trie.set('greek', 4);
 
-    assert.deepEqual(trie.find('roman'), [['roman', 1], ['romanesque', 2], ['romanesques', 3]]);
-    assert.deepEqual(trie.find('rom'), [['roman', 1], ['romanesque', 2], ['romanesques', 3]]);
-    assert.deepEqual(trie.find('romanesque'), [['romanesque', 2], ['romanesques', 3]]);
-    assert.deepEqual(trie.find('gr'), [['greek', 4]]);
-    assert.deepEqual(trie.find('hello'), []);
-    assert.deepEqual(trie.find(''), [['greek', 4], ['roman', 1], ['romanesque', 2], ['romanesques', 3]]);
+    assert.deepStrictEqual(trie.find('roman'), [['roman', 1], ['romanesque', 2], ['romanesques', 3]]);
+    assert.deepStrictEqual(trie.find('rom'), [['roman', 1], ['romanesque', 2], ['romanesques', 3]]);
+    assert.deepStrictEqual(trie.find('romanesque'), [['romanesque', 2], ['romanesques', 3]]);
+    assert.deepStrictEqual(trie.find('gr'), [['greek', 4]]);
+    assert.deepStrictEqual(trie.find('hello'), []);
+    assert.deepStrictEqual(trie.find(''), [['greek', 4], ['roman', 1], ['romanesque', 2], ['romanesques', 3]]);
   });
 
   it('should work with custom tokens.', function() {
@@ -180,7 +180,7 @@ describe('TrieMap', function() {
     trie.set(['hello', 'world'], 3);
 
     assert.strictEqual(trie.size, 3);
-    assert.deepEqual(trie.root, {
+    assert.deepStrictEqual(trie.root, {
       the: {
         cat: {
           eats: {
@@ -214,7 +214,7 @@ describe('TrieMap', function() {
 
     assert.strictEqual(trie.size, 2);
 
-    assert.deepEqual(trie.find(['the']), [
+    assert.deepStrictEqual(trie.find(['the']), [
       [['the', 'mouse', 'eats', 'cheese'], 2],
       [['the', 'cat', 'eats', 'the', 'mouse'], 1]
     ]);
@@ -228,14 +228,14 @@ describe('TrieMap', function() {
 
     var values = take(trie.values());
 
-    assert.deepEqual(values, [1, 2]);
+    assert.deepStrictEqual(values, [1, 2]);
 
     trie.set('rater', 3);
     trie.set('rates', 4);
 
     values = take(trie.values('rate'));
 
-    assert.deepEqual(values, [2, 4, 3]);
+    assert.deepStrictEqual(values, [2, 4, 3]);
   });
 
   it('should be possible to iterate over the trie\'s prefixes.', function() {
@@ -246,14 +246,14 @@ describe('TrieMap', function() {
 
     var prefixes = take(trie.prefixes());
 
-    assert.deepEqual(prefixes, ['rat', 'rate']);
+    assert.deepStrictEqual(prefixes, ['rat', 'rate']);
 
     trie.set('rater', 3);
     trie.set('rates', 4);
 
     prefixes = take(trie.keys('rate'));
 
-    assert.deepEqual(prefixes, ['rate', 'rates', 'rater']);
+    assert.deepStrictEqual(prefixes, ['rate', 'rates', 'rater']);
   });
 
   it('should be possible to iterate over the trie\'s entries.', function() {
@@ -264,14 +264,14 @@ describe('TrieMap', function() {
 
     var entries = take(trie.entries());
 
-    assert.deepEqual(entries, [['rat', 1], ['rate', 2]]);
+    assert.deepStrictEqual(entries, [['rat', 1], ['rate', 2]]);
 
     trie.set('rater', 3);
     trie.set('rates', 4);
 
     entries = take(trie.entries('rate'));
 
-    assert.deepEqual(entries, [['rate', 2], ['rates', 4], ['rater', 3]]);
+    assert.deepStrictEqual(entries, [['rate', 2], ['rates', 4], ['rater', 3]]);
   });
 
   it('should be possible to iterate over the trie\'s entries using for...of.', function() {
@@ -288,7 +288,7 @@ describe('TrieMap', function() {
     var i = 0;
 
     for (var entry of trie)
-      assert.deepEqual(entry, tests[i++]);
+      assert.deepStrictEqual(entry, tests[i++]);
   });
 
   it('should be possible to create a trie from an arbitrary iterable.', function() {
@@ -300,6 +300,6 @@ describe('TrieMap', function() {
     var trie = TrieMap.from(words);
 
     assert.strictEqual(trie.size, 2);
-    assert.deepEqual(trie.get('roman'), 1);
+    assert.deepStrictEqual(trie.get('roman'), 1);
   });
 });

--- a/test/trie.js
+++ b/test/trie.js
@@ -32,7 +32,7 @@ describe('Trie', function() {
     assert.strictEqual(trie.has('ra'), false);
     assert.strictEqual(trie.has('ratings'), false);
 
-    assert.deepEqual(trie.root, {
+    assert.deepStrictEqual(trie.root, {
       r: {
         a: {
           t: {
@@ -94,7 +94,7 @@ describe('Trie', function() {
 
     assert.strictEqual(trie.size, 2);
 
-    assert.deepEqual(trie.root, {
+    assert.deepStrictEqual(trie.root, {
       r: {
         a: {
           t: {
@@ -117,7 +117,7 @@ describe('Trie', function() {
 
     assert.strictEqual(trie.size, 1);
 
-    assert.deepEqual(trie.root, {
+    assert.deepStrictEqual(trie.root, {
       t: {
         a: {
           r: {
@@ -131,7 +131,7 @@ describe('Trie', function() {
 
     assert.strictEqual(trie.size, 0);
 
-    assert.deepEqual(trie.root, {});
+    assert.deepStrictEqual(trie.root, {});
   });
 
   it('should be possible to check the existence of a sequence in the Trie.', function() {
@@ -152,12 +152,12 @@ describe('Trie', function() {
     trie.add('romanesques');
     trie.add('greek');
 
-    assert.deepEqual(trie.find('roman'), ['roman', 'romanesque', 'romanesques']);
-    assert.deepEqual(trie.find('rom'), ['roman', 'romanesque', 'romanesques']);
-    assert.deepEqual(trie.find('romanesque'), ['romanesque', 'romanesques']);
-    assert.deepEqual(trie.find('gr'), ['greek']);
-    assert.deepEqual(trie.find('hello'), []);
-    assert.deepEqual(trie.find(''), ['greek', 'roman', 'romanesque', 'romanesques']);
+    assert.deepStrictEqual(trie.find('roman'), ['roman', 'romanesque', 'romanesques']);
+    assert.deepStrictEqual(trie.find('rom'), ['roman', 'romanesque', 'romanesques']);
+    assert.deepStrictEqual(trie.find('romanesque'), ['romanesque', 'romanesques']);
+    assert.deepStrictEqual(trie.find('gr'), ['greek']);
+    assert.deepStrictEqual(trie.find('hello'), []);
+    assert.deepStrictEqual(trie.find(''), ['greek', 'roman', 'romanesque', 'romanesques']);
   });
 
   it('should work with custom tokens.', function() {
@@ -168,7 +168,7 @@ describe('Trie', function() {
     trie.add(['hello', 'world']);
 
     assert.strictEqual(trie.size, 3);
-    assert.deepEqual(trie.root, {
+    assert.deepStrictEqual(trie.root, {
       the: {
         cat: {
           eats: {
@@ -202,7 +202,7 @@ describe('Trie', function() {
 
     assert.strictEqual(trie.size, 2);
 
-    assert.deepEqual(trie.find(['the']), [
+    assert.deepStrictEqual(trie.find(['the']), [
       ['the', 'mouse', 'eats', 'cheese'],
       ['the', 'cat', 'eats', 'the', 'mouse']
     ]);
@@ -216,14 +216,14 @@ describe('Trie', function() {
 
     var prefixes = take(trie.prefixes());
 
-    assert.deepEqual(prefixes, ['rat', 'rate']);
+    assert.deepStrictEqual(prefixes, ['rat', 'rate']);
 
     trie.add('rater');
     trie.add('rates');
 
     prefixes = take(trie.keys('rate'));
 
-    assert.deepEqual(prefixes, ['rate', 'rates', 'rater']);
+    assert.deepStrictEqual(prefixes, ['rate', 'rates', 'rater']);
   });
 
   it('should be possible to iterate over the trie\'s prefixes using for...of.', function() {
@@ -240,7 +240,7 @@ describe('Trie', function() {
     var i = 0;
 
     for (var prefix of trie)
-      assert.deepEqual(prefix, tests[i++]);
+      assert.deepStrictEqual(prefix, tests[i++]);
   });
 
   it('should be possible to create a trie from an arbitrary iterable.', function() {
@@ -249,6 +249,6 @@ describe('Trie', function() {
     var trie = Trie.from(words);
 
     assert.strictEqual(trie.size, 2);
-    assert.deepEqual(trie.has('roman'), true);
+    assert.deepStrictEqual(trie.has('roman'), true);
   });
 });

--- a/test/vector.js
+++ b/test/vector.js
@@ -175,19 +175,19 @@ describe('Vector', function() {
 
     assert.strictEqual(vector.length, 3);
     assert.strictEqual(vector.capacity, 3);
-    assert.deepEqual(Array.from(vector), [1, 2, 3]);
+    assert.deepStrictEqual(Array.from(vector), [1, 2, 3]);
 
     vector = Vector.from([1, 2, 3], Uint8Array, 10);
 
     assert.strictEqual(vector.length, 3);
     assert.strictEqual(vector.capacity, 10);
-    assert.deepEqual(Array.from(vector), [1, 2, 3]);
+    assert.deepStrictEqual(Array.from(vector), [1, 2, 3]);
 
     vector = Vector.Uint8Vector.from([1, 2, 3]);
 
     assert.strictEqual(vector.length, 3);
     assert.strictEqual(vector.capacity, 3);
-    assert.deepEqual(Array.from(vector), [1, 2, 3]);
+    assert.deepStrictEqual(Array.from(vector), [1, 2, 3]);
   });
 
   it('should be possible to create a values iterator.', function() {
@@ -206,9 +206,9 @@ describe('Vector', function() {
 
     var iterator = vector.entries();
 
-    assert.deepEqual(iterator.next().value, [0, 1]);
-    assert.deepEqual(iterator.next().value, [1, 2]);
-    assert.deepEqual(iterator.next().value, [2, 3]);
+    assert.deepStrictEqual(iterator.next().value, [0, 1]);
+    assert.deepStrictEqual(iterator.next().value, [1, 2]);
+    assert.deepStrictEqual(iterator.next().value, [2, 3]);
     assert.strictEqual(iterator.next().done, true);
   });
 


### PR DESCRIPTION
Closes https://github.com/Yomguithereal/mnemonist/issues/155