### PR TITLE
Matrix test all node versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,15 +3,19 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
+
   tests:
     strategy:
       matrix:
+        # npm will not run under 10.x or earlier and so they cannot be tested
         node-version:
             - 12.x
             - 13.x
             - 14.x
             - 15.x
             - 16.x
+            - 18.x
+            - latest
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Two changes (two commits):

* adds latest and 18.x (the new lts) to the matrix. Could instead or as well add lts (which is currently the same as 18.x and latest)
* There is a lot of code that seems to serve very old node versions, but npm does not run and I'm not sure how/whether it's possible to run mocha and reveal the good and bad news of 8.x / 10.x compat.