### PR TITLE
Fix BiMap and InverseMap `get` type to allow `undefined` return

### DIFF
--- a/bi-map.d.ts
+++ b/bi-map.d.ts
@@ -13,7 +13,7 @@ export class InverseMap<K, V> implements Iterable<[K, V]> {
   set(key: K, value: V): this;
   delete(key: K): boolean;
   has(key: K): boolean;
-  get(key: K): V;
+  get(key: K): V | undefined;
   forEach(callback: (value: V, key: K, map: this) => void, scope?: any): void;
   keys(): IterableIterator<K>;
   values(): IterableIterator<V>;
@@ -33,7 +33,7 @@ export default class BiMap<K, V> implements Iterable<[K, V]> {
   set(key: K, value: V): this;
   delete(key: K): boolean;
   has(key: K): boolean;
-  get(key: K): V;
+  get(key: K): V | undefined;
   forEach(callback: (value: V, key: K, map: this) => void, scope?: any): void;
   keys(): IterableIterator<K>;
   values(): IterableIterator<V>;


### PR DESCRIPTION
BiMap and InverseMap were wrongly typed.

Example:
```ts
import { BiMap } from 'mnemonist';

const a = new BiMap<string, string>();
a.set('a', 'b');
console.log(a.get('b')); // undefined
console.log(a.inverse.get('a')); // undefined
```