### PR TITLE
Typescript definitions: Fix missing parameters in `from` static methods

### DIFF
--- a/fibonacci-heap.d.ts
+++ b/fibonacci-heap.d.ts
@@ -42,7 +42,10 @@ export class MinFibonacciHeap<T> {
   inspect(): any;
 
   // Statics
-  static from<I>(iterable: Iterable<I> | {[key: string]: I}): FibonacciHeap<I>;
+  static from<I>(
+    iterable: Iterable<I> | {[key: string]: I},
+    comparator?: FibonacciHeapComparator<I>
+  ): FibonacciHeap<I>;
 }
 
 export class MaxFibonacciHeap<T> {
@@ -61,5 +64,8 @@ export class MaxFibonacciHeap<T> {
   inspect(): any;
 
   // Statics
-  static from<I>(iterable: Iterable<I> | {[key: string]: I}): FibonacciHeap<I>;
+  static from<I>(
+    iterable: Iterable<I> | {[key: string]: I},
+    comparator?: FibonacciHeapComparator<I>
+  ): FibonacciHeap<I>;
 }

--- a/static-interval-tree.d.ts
+++ b/static-interval-tree.d.ts
@@ -20,5 +20,8 @@ export default class StaticIntervalTree<T> {
   inspect(): any;
 
   // Statics
-  static from<I>(iterable: Iterable<I> | {[key: string]: I}): StaticIntervalTree<I>;
+  static from<I>(
+    iterable: Iterable<I> | {[key: string]: I},
+    getters?: StaticIntervalTreeGettersTuple<I>
+  ): StaticIntervalTree<I>;
 }

--- a/vector.d.ts
+++ b/vector.d.ts
@@ -18,7 +18,7 @@ export default class Vector implements Iterable<number> {
   size: number;
 
   // Constructor
-  constructor(ArrayClass: IArrayLikeConstructor, length: number | VectorOptions);
+  constructor(ArrayClass: IArrayLikeConstructor, initialCapacityOrOptions: number | VectorOptions);
 
   // Methods
   clear(): void;
@@ -48,7 +48,7 @@ declare class TypedVector implements Iterable<number> {
   size: number;
 
   // Constructor
-  constructor(length: number | VectorOptions);
+  constructor(initialCapacityOrOptions: number | VectorOptions);
 
   // Methods
   clear(): void;


### PR DESCRIPTION
- Several `from` static methods were missing parameters in their signatures.
- Made constructor parameter names in vector.d.ts match the implementation parameter name. (The type def parameter name "length" was a little misleading because it sets capacity.)