### PR TITLE
Use modern JavaScript syntax for code examples

### DIFF
--- a/bi-map.md
+++ b/bi-map.md
@@ -166,7 +166,7 @@ const map = new BiMap();
 map.set('one', 'hello');
 map.set('two', 'world');
 
-map.forEach(function(value, key) {
+map.forEach((value, key) => {
   console.log(key, value);
 });
 >>> 'one', 'hello'

--- a/bi-map.md
+++ b/bi-map.md
@@ -14,13 +14,13 @@ Here are the three conflicting cases you need to keep in mind:
 3. If the `{A,B}` and `{C,D}` relation exists in the `BiMap` and you add the `{A,D}` one, you will delete both former ones (both key & value conflict).
 
 ```js
-var BiMap = require('mnemonist/bi-map');
+const BiMap = require('mnemonist/bi-map');
 ```
 
 ## Constructor
 
 ```js
-var map = new BiMap();
+const map = new BiMap();
 ```
 
 ### Static #.from
@@ -28,7 +28,7 @@ var map = new BiMap();
 Alternatively, one can build a `BiMap` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var map = BiMap.from({one: 'hello', two: 'world'});
+const map = BiMap.from({one: 'hello', two: 'world'});
 ```
 
 ## Members
@@ -62,7 +62,7 @@ var map = BiMap.from({one: 'hello', two: 'world'});
 You can access the inverse map through this member.
 
 ```js
-var map = new BiMap();
+const map = new BiMap();
 
 map.set('one', 'hello');
 map.inverse.get('hello');
@@ -74,7 +74,7 @@ map.inverse.get('hello');
 Total number of items stored by the map.
 
 ```js
-var map = new BiMap();
+const map = new BiMap();
 
 map.set('one', 'hello');
 
@@ -89,7 +89,7 @@ Creates a relation in the bimap between key and value.
 `O(1) amortized`
 
 ```js
-var map = new BiMap();
+const map = new BiMap();
 
 map.set(key, item);
 ```
@@ -101,7 +101,7 @@ map.set(key, item);
 Removes the relation associated with the given key.
 
 ```js
-var map = new BiMap();
+const map = new BiMap();
 
 map.set('one', 'hello');
 
@@ -115,7 +115,7 @@ map.size
 Completely clears the bimap of its relations.
 
 ```js
-var map = new BiMap();
+const map = new BiMap();
 
 map.set('one', 'hello');
 map.set('two', 'world');
@@ -133,7 +133,7 @@ Returns whether the map has the given key.
 `O(1) amortized`
 
 ```js
-var map = new BiMap();
+const map = new BiMap();
 
 map.set('one', 'hello');
 
@@ -148,7 +148,7 @@ Returns the value stored at the given key.
 `O(1) amortized`
 
 ```js
-var map = new BiMap();
+const map = new BiMap();
 
 map.set('one', 'hello');
 
@@ -161,7 +161,7 @@ map.get('one');
 Iterates over each of the entries of the bimap.
 
 ```js
-var map = new BiMap();
+const map = new BiMap();
 
 map.set('one', 'hello');
 map.set('two', 'world');
@@ -178,12 +178,12 @@ map.forEach(function(value, key) {
 Returns an iterator over the keys of the bimap.
 
 ```js
-var map = new BiMap();
+const map = new BiMap();
 
 map.set('one', 'hello');
 map.set('two', 'world');
 
-var iterator = map.keys();
+const iterator = map.keys();
 
 iterator.next().value
 >>> 'one'
@@ -194,12 +194,12 @@ iterator.next().value
 Returns an iterator over the values of the bimap.
 
 ```js
-var map = new BiMap();
+const map = new BiMap();
 
 map.set('one', 'hello');
 map.set('two', 'world');
 
-var iterator = map.values();
+const iterator = map.values();
 
 iterator.next().value
 >>> 'hello'
@@ -210,12 +210,12 @@ iterator.next().value
 Returns an iterator over the entries of the bimap.
 
 ```js
-var map = new BiMap();
+const map = new BiMap();
 
 map.set('one', 'hello');
 map.set('two', 'world');
 
-var iterator = map.entries();
+const iterator = map.entries();
 
 iterator.next().value
 >>> ['one', 'hello']
@@ -226,12 +226,12 @@ iterator.next().value
 Alternatively, you can iterate over a list's entries using ES2015 `for...of` protocol:
 
 ```js
-var map = new BiMap();
+const map = new BiMap();
 
 map.set('one', 'hello');
 map.set('two', 'world');
 
-for (var entry of map) {
+for (const entry of map) {
   console.log(entry);
 }
 ```

--- a/bit-set.md
+++ b/bit-set.md
@@ -231,7 +231,7 @@ const set = new BitSet(4);
 
 set.set(1);
 
-set.forEach(function(bit, i) {
+set.forEach((bit, i) => {
   console.log(bit, i);
 });
 ```

--- a/bit-set.md
+++ b/bit-set.md
@@ -9,13 +9,13 @@ Note that if you need a `BitSet` whose size is able to grow dynamically if requi
 
 
 ```js
-var BitSet = require('mnemonist/bit-set');
+const BitSet = require('mnemonist/bit-set');
 ```
 
 ## Constructor
 
 ```js
-var set = new BitSet(length);
+const set = new BitSet(length);
 ```
 
 ## Members
@@ -52,7 +52,7 @@ var set = new BitSet(length);
 The underlying `Uint8Array`.
 
 ```js
-var set = new BitSet(19);
+const set = new BitSet(19);
 
 set.array;
 >>> Uint8Array [0, 0, 0]
@@ -63,7 +63,7 @@ set.array;
 Length of the set, that is to say the number of bits stored by the set.
 
 ```js
-var set = new BitSet(4);
+const set = new BitSet(4);
 
 set.length;
 >>> 4
@@ -74,7 +74,7 @@ set.length;
 Number of bits set, that is to say the total number of ones stored by the set.
 
 ```js
-var set = new BitSet(4);
+const set = new BitSet(4);
 
 set.size;
 >>> 0
@@ -92,7 +92,7 @@ Sets the bit at the given index. Optionally you can indicate (`0` or `1` obvious
 `O(1)`
 
 ```js
-var set = new BitSet(4);
+const set = new BitSet(4);
 
 set.set(3);
 set.test(3);
@@ -110,7 +110,7 @@ Resets the bit at the given index, meaning setting it to `0`.
 `O(1)`
 
 ```js
-var set = new BitSet(4);
+const set = new BitSet(4);
 
 set.set(3);
 set.reset(3);
@@ -125,7 +125,7 @@ Toggles the bit at the given index.
 `O(1)`
 
 ```js
-var set = new BitSet(4);
+const set = new BitSet(4);
 
 set.flip(3);
 set.test(3);
@@ -140,7 +140,7 @@ set.test(3);
 Resets every bit stored by the set.
 
 ```js
-var set = new BitSet(4);
+const set = new BitSet(4);
 
 set.set(1);
 set.set(3);
@@ -157,7 +157,7 @@ Returns the bit at the given index.
 `O(1)`
 
 ```js
-var set = new BitSet(4);
+const set = new BitSet(4);
 
 set.set(1);
 
@@ -175,7 +175,7 @@ Returns the number of bits set to 1 up to (but not including) the provided index
 `O(i)`, i being the provided index.
 
 ```js
-var set = new BitSet(4);
+const set = new BitSet(4);
 
 set.set(1);
 set.set(2);
@@ -193,7 +193,7 @@ Returns the index of the nth bit set to 1 in the set.
 `O(n)`
 
 ```js
-var set = new BitSet(4);
+const set = new BitSet(4);
 
 set.set(0);
 set.set(2);
@@ -211,7 +211,7 @@ Test the bit at the given index, returning a boolean.
 `O(1)`
 
 ```js
-var set = new BitSet(4);
+const set = new BitSet(4);
 
 set.set(1);
 
@@ -227,7 +227,7 @@ set.test(3);
 Iterates over the set's bits.
 
 ```js
-var set = new BitSet(4);
+const set = new BitSet(4);
 
 set.set(1);
 
@@ -241,11 +241,11 @@ set.forEach(function(bit, i) {
 Returns an iterator over the set's values.
 
 ```js
-var set = new BitSet(4);
+const set = new BitSet(4);
 
 set.set(1);
 
-var iterator = set.values()
+const iterator = set.values()
 
 iteraror.next().value
 >>> 0
@@ -256,11 +256,11 @@ iteraror.next().value
 Returns an iterator over the set's entries.
 
 ```js
-var set = new BitSet(4);
+const set = new BitSet(4);
 
 set.set(0);
 
-var iterator = set.entries()
+const iterator = set.entries()
 
 iteraror.next().value
 >>> [0, 1]
@@ -274,9 +274,9 @@ iterator.next().value
 Alternatively, you can iterate over a set's values using ES2015 `for...of` protocol:
 
 ```js
-var set = new BitSet(4);
+const set = new BitSet(4);
 
-for (var bit of set) {
+for (const bit of set) {
   console.log(bit);
 }
 ```

--- a/bit-vector.md
+++ b/bit-vector.md
@@ -331,7 +331,7 @@ const vector = new BitVector(4);
 
 vector.set(1);
 
-vector.forEach(function(bit, i) {
+vector.forEach((bit, i) => {
   console.log(bit, i);
 });
 ```

--- a/bit-vector.md
+++ b/bit-vector.md
@@ -6,13 +6,13 @@ title: BitVector
 The `BitVector` is the same thing as the [`BitSet`]({{ site.baseurl }}/bit-set), except it can grow dynamically if required.
 
 ```js
-var BitVector = require('mnemonist/bit-set');
+const BitVector = require('mnemonist/bit-set');
 ```
 
 ## Constructor
 
 ```js
-var vector = new BitVector(length);
+const vector = new BitVector(length);
 ```
 
 ## Members
@@ -55,7 +55,7 @@ var vector = new BitVector(length);
 The underlying `Uint8Array`.
 
 ```js
-var vector = new BitVector(19);
+const vector = new BitVector(19);
 
 vector.array;
 >>> Uint8Array [0, 0, 0]
@@ -68,7 +68,7 @@ Number of bits that can be stored by the vector before needing to reallocate mem
 Note that since bits are stored on the bytes of a `Uint32Array`, capacity will snap at the nearest multiple of 32.
 
 ```js
-var vector = new BitVector(53);
+const vector = new BitVector(53);
 
 vector.capacity
 >>> 64
@@ -79,7 +79,7 @@ vector.capacity
 Length of the set, that is to say the number of bits stored by the vector.
 
 ```js
-var vector = new BitVector(4);
+const vector = new BitVector(4);
 
 vector.length;
 >>> 4
@@ -90,7 +90,7 @@ vector.length;
 Number of bits set, that is to say the total number of ones stored by the vector.
 
 ```js
-var vector = new BitVector(4);
+const vector = new BitVector(4);
 
 vector.size;
 >>> 0
@@ -108,7 +108,7 @@ Applies the growing policy once and reallocates the underlying vector.
 If given a number, will run the growing policy until we attain a suitable capacity.
 
 ```js
-var vector = new BitVector();
+const vector = new BitVector();
 
 vector.grow();
 
@@ -125,7 +125,7 @@ Note that this method won't deallocate memory. You can use [#.reallocate](#reall
 `O(1)`
 
 ```js
-var vector = new BitVector();
+const vector = new BitVector();
 
 vector.push(1);
 vector.push(1);
@@ -141,7 +141,7 @@ Push a bit into the vector.
 `O(1) amortized`
 
 ```js
-var vector = new BitVector();
+const vector = new BitVector();
 
 vector.push(1);
 vector.push(false);
@@ -154,7 +154,7 @@ Sets the bit at the given index. Optionally you can indicate the bit's value (`0
 `O(1)`
 
 ```js
-var vector = new BitVector(4);
+const vector = new BitVector(4);
 
 vector.set(3);
 vector.test(3);
@@ -170,7 +170,7 @@ vector.test(3);
 Reallocates the underlying array and truncates length if needed.
 
 ```js
-var vector = new BitVector();
+const vector = new BitVector();
 
 vector.reallocate(75);
 
@@ -187,7 +187,7 @@ Resets the bit at the given index, meaning setting it to `0`.
 `O(1)`
 
 ```js
-var vector = new BitVector(4);
+const vector = new BitVector(4);
 
 vector.set(3);
 vector.reset(3);
@@ -202,7 +202,7 @@ Resize the vector's length. Will reallocate if current capacity is insufficient.
 Note that it won't deallocate if the given length is inferior to the current one. You can use [#.reallocate](#reallocate) for that.
 
 ```js
-var vector = new BitVector(10);
+const vector = new BitVector(10);
 
 vector.resize(5);
 vector.length;
@@ -225,7 +225,7 @@ Toggles the bit at the given index.
 `O(1)`
 
 ```js
-var vector = new BitVector(4);
+const vector = new BitVector(4);
 
 vector.flip(3);
 vector.test(3);
@@ -240,7 +240,7 @@ vector.test(3);
 Resets every bit stored by the vector.
 
 ```js
-var vector = new BitVector(4);
+const vector = new BitVector(4);
 
 vector.set(1);
 vector.set(3);
@@ -257,7 +257,7 @@ Returns the bit at the given index.
 `O(1)`
 
 ```js
-var vector = new BitVector(4);
+const vector = new BitVector(4);
 
 vector.set(1);
 
@@ -275,7 +275,7 @@ Returns the number of bits set to 1 up to (but not including) the provided index
 `O(i)`, i being the provided index.
 
 ```js
-var vector = new BitVector(4);
+const vector = new BitVector(4);
 
 vector.set(1);
 vector.set(2);
@@ -293,7 +293,7 @@ Returns the index of the nth bit set to 1 in the vector.
 `O(n)`
 
 ```js
-var vector = new BitVector(4);
+const vector = new BitVector(4);
 
 vector.set(0);
 vector.set(2);
@@ -311,7 +311,7 @@ Test the bit at the given index, returning a boolean.
 `O(1)`
 
 ```js
-var vector = new BitVector(4);
+const vector = new BitVector(4);
 
 vector.set(1);
 
@@ -327,7 +327,7 @@ vector.test(3);
 Iterates over the set's bits.
 
 ```js
-var vector = new BitVector(4);
+const vector = new BitVector(4);
 
 vector.set(1);
 
@@ -341,11 +341,11 @@ vector.forEach(function(bit, i) {
 Returns an iterator over the set's values.
 
 ```js
-var vector = new BitVector(4);
+const vector = new BitVector(4);
 
 vector.set(1);
 
-var iterator = vector.values()
+const iterator = vector.values()
 
 iteraror.next().value
 >>> 0
@@ -356,11 +356,11 @@ iteraror.next().value
 Returns an iterator over the set's entries.
 
 ```js
-var vector = new BitVector(4);
+const vector = new BitVector(4);
 
 vector.set(0);
 
-var iterator = vector.entries()
+const iterator = vector.entries()
 
 iteraror.next().value
 >>> [0, 1]
@@ -374,9 +374,9 @@ iterator.next().value
 Alternatively, you can iterate over a set's values using ES2015 `for...of` protocol:
 
 ```js
-var vector = new BitVector(4);
+const vector = new BitVector(4);
 
-for (var bit of vector) {
+for (const bit of vector) {
   console.log(bit);
 }
 ```

--- a/bk-tree.md
+++ b/bk-tree.md
@@ -8,7 +8,7 @@ A `BKTree` is a data structure that makes possible to make efficient fuzzy query
 For more information about the Burkhard-Keller Tree, you can head [here](https://en.wikipedia.org/wiki/BK-tree).
 
 ```js
-var BKTree = require('mnemonist/bk-tree');
+const BKTree = require('mnemonist/bk-tree');
 ```
 
 ## Use case
@@ -20,9 +20,7 @@ When the user inputs a string, we are going to search for every term we know bei
 The naive method would be to "brute-force" the list of terms likewise:
 
 ```js
-var suggestions = terms.filter(term => {
-  return levenshtein(term, query) <= 2;
-});
+const suggestions = terms.filter((term) => levenshtein(term, query) <= 2);
 ```
 
 But, even if this works with few terms, it will soon become hard to compute if the list of terms grows too much.
@@ -30,10 +28,10 @@ But, even if this works with few terms, it will soon become hard to compute if t
 Burkhard-Keller trees solves this problem by indexing the list of terms such as it becomes efficient to query them using a distance metric.
 
 ```js
-var tree = BKTtree.from(terms, levenshtein);
+const tree = BKTtree.from(terms, levenshtein);
 
 // We can now query the tree easily:
-var suggestions = tree.search(2, query);
+const suggestions = tree.search(2, query);
 ```
 
 **N.B.** you should probably also check the [PassjoinIndex]({{ site.baseurl }}/passjoin-index) structure, which is able to perform the same kind of job but is even more efficient for this precise use case.
@@ -43,7 +41,7 @@ var suggestions = tree.search(2, query);
 The `BKTree` takes a single argument being the distance metric to use.
 
 ```js
-var tree = new BKTree(distance);
+const tree = new BKTree(distance);
 ```
 
 **N.B.** the given distance metric must return integers. As such, the [Jaccard index](https://en.wikipedia.org/wiki/Jaccard_index), for instance, is not suitable to use with this data strucure.
@@ -55,7 +53,7 @@ What's more, only a [true metric](https://en.wikipedia.org/wiki/Metric_(mathemat
 Alternatively, one can build a `BKTree` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var tree = BKTree.from(['hello', 'mello'], distance);
+const tree = BKTree.from(['hello', 'mello'], distance);
 ```
 
 ## Members
@@ -78,7 +76,7 @@ var tree = BKTree.from(['hello', 'mello'], distance);
 Total number of items stored in the tree.
 
 ```js
-var tree = new BKTree(distance);
+const tree = new BKTree(distance);
 
 tree.add('hello');
 
@@ -91,7 +89,7 @@ tree.size
 Adds a single item to the tree.
 
 ```js
-var tree = new BKTree(distance);
+const tree = new BKTree(distance);
 
 tree.add('hello');
 ```
@@ -101,7 +99,7 @@ tree.add('hello');
 Completely clears the tree of its items.
 
 ```js
-var tree = new BKTree(distance);
+const tree = new BKTree(distance);
 
 tree.add('hello');
 tree.clear();
@@ -115,7 +113,7 @@ tree.size
 Returns every item in the tree within the desired distance.
 
 ```js
-var tree = new BKTree(distance);
+const tree = new BKTree(distance);
 
 tree.add('hello');
 tree.add('mello');

--- a/bloom-filter.md
+++ b/bloom-filter.md
@@ -14,7 +14,7 @@ Moreover, because it stores information on byte arrays, a `BloomFilter` cannot h
 For more information about the `BloomFilter`, you can head [here](https://en.wikipedia.org/wiki/Bloom_filter).
 
 ```js
-var BloomFilter = require('mnemonist/bloom-filter');
+const BloomFilter = require('mnemonist/bloom-filter');
 ```
 
 Note that by default, this implementation uses `murmurhash3` and is designed to store strings only.
@@ -27,10 +27,12 @@ Alternatively, you can provide a configuration object if you also need to tweaks
 
 ```js
 // Creating a bloom filter that can hold 50 items
-var filter = new BloomFilter(50);
+const filter = new BloomFilter(50);
+```
 
+```js
 // Passing custom options
-var filter = new BloomFilter({
+const filter = new BloomFilter({
   capacity: 2500,
   errorRate: .05
 });
@@ -41,7 +43,7 @@ var filter = new BloomFilter({
 Alternatively, one can build a `BloomFilter` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var filter = BloomFilter.from([1, 2, 3], options);
+const filter = BloomFilter.from([1, 2, 3], options);
 ```
 
 ## Members
@@ -66,7 +68,7 @@ var filter = BloomFilter.from([1, 2, 3], options);
 Total number of items the filter is able to store.
 
 ```js
-var filter = new BloomFilter(5);
+const filter = new BloomFilter(5);
 
 filter.capacity
 >>> 5
@@ -77,7 +79,7 @@ filter.capacity
 Error rate of the filter. Defaults to `0.005`.
 
 ```js
-var filter = new BloomFilter(5);
+const filter = new BloomFilter(5);
 
 filter.errorRate
 >>> 0.005
@@ -88,7 +90,7 @@ filter.errorRate
 Number of hash functions.
 
 ```js
-var filter = new BloomFilter(3);
+const filter = new BloomFilter(3);
 
 filter.hashFunctions
 >>> 7
@@ -101,7 +103,7 @@ Add the given item to the filter.
 `O(k)`, k being the number of hash functions.
 
 ```js
-var filter = new BloomFilter(5);
+const filter = new BloomFilter(5);
 filter.add('hello');
 ```
 
@@ -110,7 +112,7 @@ filter.add('hello');
 Completely clears the filter of its items.
 
 ```js
-var filter = new BloomFilter(5);
+const filter = new BloomFilter(5);
 filter.add('hello');
 filter.clear();
 
@@ -125,7 +127,7 @@ Will return `false` if the item is not present in the filter and `true` if the i
 `O(k)`, k being the number of hash functions.
 
 ```js
-var filter = new BloomFilter(5);
+const filter = new BloomFilter(5);
 filter.add('hello');
 
 filter.test('world');

--- a/circular-buffer.md
+++ b/circular-buffer.md
@@ -12,7 +12,7 @@ For more information about the circular buffer, you can head [here](https://en.w
 Note, that contrary to the [`FixedDeque`]({{ site.baseurl }}/fixed-deque), the `CircularBuffer` will overwrite old values when overflowing capacity.
 
 ```js
-var CircularBuffer = require('mnemonist/circular-buffer');
+const CircularBuffer = require('mnemonist/circular-buffer');
 ```
 
 ## Constructor
@@ -20,10 +20,11 @@ var CircularBuffer = require('mnemonist/circular-buffer');
 The `CircularBuffer` takes two arguments: a array class to use, and the desired capacity.
 
 ```js
-var buffer = new CircularBuffer(Array, 10);
-
+const buffer = new CircularBuffer(Array, 10);
+```
+```js
 // Using byte arrays
-var buffer = new CircularBuffer(Int8Array, 10);
+const buffer = new CircularBuffer(Int8Array, 10);
 ```
 
 ### Static #.from
@@ -32,10 +33,11 @@ Alternatively, one can build a `CircularBuffer` from an arbitrary JavaScript ite
 
 ```js
 // Attempting the guess the given iterable's length/size
-var buffer = CircularBuffer.from([1, 2, 3], Int8Array);
-
+const buffer = CircularBuffer.from([1, 2, 3], Int8Array);
+```
+```js
 // Providing the desired capacity
-var buffer = CircularBuffer.from([1, 2, 3], Int8Array, 10);
+const buffer = CircularBuffer.from([1, 2, 3], Int8Array, 10);
 ```
 
 ## Members
@@ -71,7 +73,7 @@ var buffer = CircularBuffer.from([1, 2, 3], Int8Array, 10);
 Maximum number of items the buffer is able to store.
 
 ```js
-var buffer = new CircularBuffer(Array, 10);
+const buffer = new CircularBuffer(Array, 10);
 buffer.capacity
 >>> 10
 ```
@@ -81,7 +83,7 @@ buffer.capacity
 Number of items in the buffer.
 
 ```js
-var buffer = new CircularBuffer(Array, 10);
+const buffer = new CircularBuffer(Array, 10);
 buffer.size
 >>> 0
 ```
@@ -95,7 +97,7 @@ Will overwrite first value when the buffer's capacity is exceeded.
 `O(1)`
 
 ```js
-var buffer = new CircularBuffer(Array, 10);
+const buffer = new CircularBuffer(Array, 10);
 
 buffer.push(1);
 ```
@@ -109,7 +111,7 @@ Will overwrite the last value when the buffer's capacity is exceeded.
 `O(1)`
 
 ```js
-var buffer = new CircularBuffer(Array, 10);
+const buffer = new CircularBuffer(Array, 10);
 
 buffer.unshift(1);
 ```
@@ -121,7 +123,7 @@ Retrieve & remove the last item of the buffer.
 `O(1)`
 
 ```js
-var buffer = new CircularBuffer(Array, 10);
+const buffer = new CircularBuffer(Array, 10);
 
 buffer.push(1);
 buffer.push(2);
@@ -136,7 +138,7 @@ Retrieve & remove the first item of the buffer.
 `O(1)`
 
 ```js
-var buffer = new CircularBuffer(Array, 10);
+const buffer = new CircularBuffer(Array, 10);
 
 buffer.push(1);
 buffer.push(2);
@@ -151,7 +153,7 @@ Completely clears the buffer.
 `O(1)`
 
 ```js
-var buffer = new CircularBuffer(Array, 10);
+const buffer = new CircularBuffer(Array, 10);
 
 buffer.push(1);
 buffer.clear();
@@ -166,7 +168,7 @@ Retrieves the first item of the buffer.
 `O(1)`
 
 ```js
-var buffer = new CircularBuffer(Array, 10);
+const buffer = new CircularBuffer(Array, 10);
 
 buffer.push(1);
 buffer.push(2);
@@ -181,7 +183,7 @@ Retrieves the last item of the buffer.
 `O(1)`
 
 ```js
-var buffer = new CircularBuffer(Array, 10);
+const buffer = new CircularBuffer(Array, 10);
 
 buffer.push(1);
 buffer.push(2);
@@ -194,7 +196,7 @@ buffer.peekLast();
 Iterates over the buffer's values.
 
 ```js
-var buffer = new CircularBuffer(Array, 10);
+const buffer = new CircularBuffer(Array, 10);
 
 buffer.push(1);
 buffer.push(2);
@@ -211,7 +213,7 @@ Converts the buffer into a JavaScript array.
 Note that the resulting array will be instantiated using the provided class.
 
 ```js
-var buffer = new CircularBuffer(Array, 10);
+const buffer = new CircularBuffer(Array, 10);
 
 buffer.push(1);
 buffer.push(2);
@@ -225,9 +227,9 @@ buffer.toArray();
 Returns an iterator over the buffer's values.
 
 ```js
-var buffer = CircularBuffer.from([1, 2, 3], Array);
+const buffer = CircularBuffer.from([1, 2, 3], Array);
 
-var iterator = buffer.values();
+const iterator = buffer.values();
 
 iterator.next().value
 >>> 1
@@ -238,9 +240,9 @@ iterator.next().value
 Returns an iterator over the buffer's entries.
 
 ```js
-var buffer = CircularBuffer.from([1, 2, 3], Array);
+const buffer = CircularBuffer.from([1, 2, 3], Array);
 
-var iterator = buffer.entries();
+const iterator = buffer.entries();
 
 iterator.next().value
 >>> [0, 1]
@@ -251,9 +253,9 @@ iterator.next().value
 Alternatively, you can iterate over a buffer's values using ES2015 `for...of` protocol:
 
 ```js
-var buffer = CircularBuffer.from([1, 2, 3], Array);
+const buffer = CircularBuffer.from([1, 2, 3], Array);
 
-for (var item of buffer) {
+for (const item of buffer) {
   console.log(item);
 }
 ```

--- a/circular-buffer.md
+++ b/circular-buffer.md
@@ -201,7 +201,7 @@ const buffer = new CircularBuffer(Array, 10);
 buffer.push(1);
 buffer.push(2);
 
-buffer.forEach(function(item, index, buffer) {
+buffer.forEach((item, index, buffer) => {
   console.log(index, item);
 });
 ```

--- a/composite-index.md
+++ b/composite-index.md
@@ -8,7 +8,7 @@ The `CompositeIndex` is an abstraction over the [`Index`]({{ site.baseurl }}/ind
 It basically store the given items in various subindices in order to be able to query them using different methods.
 
 ```js
-var CompositeIndex = require('mnemonist/composite-index');
+const CompositeIndex = require('mnemonist/composite-index');
 ```
 
 ## Use case
@@ -23,27 +23,19 @@ Therefore, we want an index able to store & query our organizations using variou
 // Let's create an index that using two different hashing methods:
 // 1. Lowercase organization name
 // 2. Uppercase organization acronym
-var index = new CompositeIndex([
+const index = new CompositeIndex([
   {
     name: 'name',
     hash: [
-      function(org) {
-        return org.name.toLowerCase();
-      },
-      function(query) {
-        return query.toLowerCase();
-      }
+      (org) => org.name.toLowerCase(),
+      (query) => query.toLowerCase(),
     ]
   },
   {
     name: 'acronym',
     hash: [
-      function(org) {
-        return org.acronym.toUpperCase();
-      },
-      function(query) {
-        return query.toUpperCase();
-      }
+      (org) => org.acronym.toUpperCase(),
+      (query) => query.toUpperCase(),
     ]
   }
 ]);
@@ -72,10 +64,10 @@ index.get('WHO');
 >>> undefined
 
 // Now, let's say we have the following entry, with a year for NATO
-var entry = {acronym: 'nato', year: 1947}
+const entry = {acronym: 'nato', year: 1947}
 
 // We will be able to find it in the index & be able to merge information
-var match = index.get(entry.acronym);
+const match = index.get(entry.acronym);
 match.year = entry.year;
 ```
 
@@ -87,9 +79,7 @@ The `CompositeIndex` takes as single argument a list of subindices descriptors.
 // A descriptor must have a name & either a single hash function
 {
   name: 'acronym',
-  hash: function(string) {
-    return string.toUpperCase();
-  }
+  hash: (string) => string.toUpperCase(),
 }
 
 // Or a descriptor can have two hash functions
@@ -97,12 +87,8 @@ The `CompositeIndex` takes as single argument a list of subindices descriptors.
 {
   name: 'acronym',
   hash: [
-    function(item) {
-      return item.acronym.toUpperCase();
-    },
-    function(query) {
-      return query.toUpperCase();
-    }
+    (item) => item.acronym.toUpperCase(),
+    (query) => query.toUpperCase(),
   ]
 }
 ```
@@ -110,16 +96,14 @@ The `CompositeIndex` takes as single argument a list of subindices descriptors.
 **Warning!**: the index will not consider any falsy key processed by its hash functions.
 
 ```js
-var index = new Index([
+const index = new Index([
   {
     name: 'lowercase',
-    hash: function(item) {
-      return item.title && item.title.toLowerCase();
-    }  
+    hash: (item) => item.title && item.title.toLowerCase(),
   }
 ]);
 
-var movie = {year: 1999};
+const movie = {year: 1999};
 
 // This will not be indexed on `undefined`
 index.set(movie.title, movie);
@@ -130,7 +114,7 @@ index.set(movie.title, movie);
 Alternatively, one can build a `CompositeIndex` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var index = CompositeIndex.from(list, descriptors [, useSet=false]);
+const index = CompositeIndex.from(list, descriptors [, useSet=false]);
 ```
 
 ## Members
@@ -160,27 +144,19 @@ var index = CompositeIndex.from(list, descriptors [, useSet=false]);
 Number of distinct items stored in the index.
 
 ```js
-var index = new CompositeIndex([
+const index = new CompositeIndex([
   {
     name: 'lowercase',
     hash: [
-      function(item) {
-        return item.title.toLowerCase();
-      },
-      function(query) {
-        return query.toLowerCase();
-      }
+      (item) => item.title.toLowerCase(),
+      (query) => query.toLowerCase(),
     ]
   },
   {
     name: 'uppercase',
     hash: [
-      function(item) {
-        return item.title.toUpperCase();
-      },
-      function(query) {
-        return query.toUpperCase();
-      }
+      (item) => item.title.toUpperCase(),
+      (query) => query.toUpperCase(),
     ]
   }
 ]);
@@ -198,22 +174,18 @@ index.size
 Hashes the given item to produce its keys using the relevant function then sets this item in each of the subindices for which the hashed key is not falsy.
 
 ```js
-var index = new CompositeIndex({
+const index = new CompositeIndex({
   name: 'lowercase',
   hash: [
-    function(item) {
-      return item.title.toLowerCase();
-    },
-    function(query) {
-      return query.toLowerCase();
-    }
+    (item) => item.title.toLowerCase(),
+    (query) => query.toLowerCase(),
   ]
 });
 
 index.add({title: 'Great movie', year: 1999});
 
 // In fact, same as doing
-var movie = {title: 'Great movie', year: 1999};
+const movie = {title: 'Great movie', year: 1999};
 index.set(movie, movie);
 ```
 
@@ -222,14 +194,12 @@ index.set(movie, movie);
 Hashes the given key using the relevant function then sets the given item in each of the subindices for which the hashed key is not falsy.
 
 ```js
-var index = new CompositeIndex({
+const index = new CompositeIndex({
   name: 'lowercase',
-  hash: function(string) {
-    return string.toLowerCase();
-  }
+  hash: (string) => string.toLowerCase()
 });
 
-var movie = {title: 'Great movie', year: 1999};
+const movie = {title: 'Great movie', year: 1999};
 
 index.set(movie.title, movie);
 ```
@@ -239,7 +209,7 @@ index.set(movie.title, movie);
 Completely clears the index of its items.
 
 ```js
-var index = new CompositeIndex(...);
+const index = new CompositeIndex(...);
 index.add(item);
 index.clear();
 
@@ -252,24 +222,18 @@ index.size
 Retrieves an item in the index by testing each of the subindices, or a subset of the subindices that you can test in an arbitrary order.
 
 ```js
-var index = new CompositeIndex([
+const index = new CompositeIndex([
   {
     name: 'lowercase',
-    hash: function(string) {
-      return string.toLowerCase();
-    }
+    hash: (string) => string.toLowerCase()
   },
   {
     name: 'firstLetter',
-    hash: function(string) {
-      return string[0].toLowerCase();
-    }
+    hash: (string) => string[0].toLowerCase()
   },
   {
     name: 'lastLetter',
-    hash: function(string) {
-      return string[string.length - 1].toLowerCase();
-    }
+    hash: (string) => string[string.length - 1].toLowerCase()
   }
 ]);
 
@@ -289,19 +253,15 @@ index.has(['firstLetter', 'lowercase'], 'r');
 Iterates over the items stored in the index.
 
 ```js
-var index = new CompositeIndex({
+const index = new CompositeIndex({
   name: 'lowercase',
-  hash: function(string) {
-    return string.toLowerCase();
-  }
+   hash: (string) => string.toLowerCase()
 });
 
 index.set('Hello', {name: 'hello'});
 index.set('World', {name: 'world'});
 
-index.forEach(function(value) {
-  console.log(value);
-});
+index.forEach((value) => console.log(value));
 >>> {name: 'hello'}
 >>> {name: 'world'}
 ```
@@ -311,17 +271,15 @@ index.forEach(function(value) {
 Creates an iterator over the index's values.
 
 ```js
-var index = new CompositeIndex({
+const index = new CompositeIndex({
   name: 'lowercase',
-  hash: function(string) {
-    return string.toLowerCase();
-  }
+  hash: (string) => string.toLowerCase()
 });
 
 index.set('Hello', {name: 'hello'});
 index.set('World', {name: 'world'});
 
-var iterator = index.values();
+const iterator = index.values();
 iterator.next().value();
 >>> {name: 'hello'}
 ```
@@ -331,17 +289,15 @@ iterator.next().value();
 Alternatively, you can iterate over an index' values using ES2015 `for...of` protocol:
 
 ```js
-var index = new CompositeIndex({
+const index = new CompositeIndex({
   name: 'lowercase',
-  hash: function(string) {
-    return string.toLowerCase();
-  }
+  hash: (string) => string.toLowerCase()
 });
 
 index.set('Hello', {name: 'hello'});
 index.set('World', {name: 'world'});
 
-for (var value of index) {
+for (const value of index) {
   console.log(value);
 }
 ```

--- a/composite-index.md
+++ b/composite-index.md
@@ -261,7 +261,9 @@ const index = new CompositeIndex({
 index.set('Hello', {name: 'hello'});
 index.set('World', {name: 'world'});
 
-index.forEach((value) => console.log(value));
+index.forEach((value) => {
+  console.log(value)
+});
 >>> {name: 'hello'}
 >>> {name: 'world'}
 ```

--- a/default-map.md
+++ b/default-map.md
@@ -8,7 +8,7 @@ A `DefaultMap` is simply a `Map` that will use the given factory to automaticall
 It's basically the same thing as python's renowned [defaultdict](https://docs.python.org/3.7/library/collections.html#collections.defaultdict).
 
 ```js
-var DefaultMap = require('mnemonist/default-map');
+const DefaultMap = require('mnemonist/default-map');
 ```
 
 ## Use case
@@ -20,7 +20,7 @@ This is the exact problem `DefaultMap` tries to address.
 Let's say we want to have keys pointing to arrays of values:
 
 ```js
-var personsToGroup = {
+const personsToGroup = {
   John: 1,
   Martha: 2,
   Philip: 1,
@@ -35,10 +35,10 @@ var personsToGroup = {
 // }
 
 // Using a Map
-var map = new Map();
+const map = new Map();
 
-for (var person in personsToGroup) {
-  var group = personsToGroup[person];
+for (const person in personsToGroup) {
+  const group = personsToGroup[person];
 
   // This is tedious & leads to more lookups if written carelessly
   if (!map.has(group))
@@ -48,10 +48,10 @@ for (var person in personsToGroup) {
 }
 
 // Using a DefaultMap
-var map = new DefaultMap(() => []);
+const map = new DefaultMap(() => []);
 
-for (var person in personsToGroup) {
-  var group = personsToGroup[person];
+for (const person in personsToGroup) {
+  const group = personsToGroup[person];
 
   map.get(group).push(person);
 }
@@ -61,10 +61,11 @@ But there are plenty of other use cases. Why not use the `DefaultMap` with more 
 
 ```js
 // Maps K => <V, number>
-var map = new DefaultMap(() => new MultiSet());
-
+const map = new DefaultMap(() => new MultiSet());
+```
+```js
 // Let's be creative :)
-var map = new DefaultMap(() => new DefaultMap(() => []));
+const map = new DefaultMap(() => new DefaultMap(() => []));
 ```
 
 ## Constructor
@@ -72,12 +73,12 @@ var map = new DefaultMap(() => new DefaultMap(() => []));
 The `DefaultMap` takes a factory function as single argument.
 
 ```js
-var map = new DefaultMap(() => []);
+const map = new DefaultMap(() => []);
 
 map.get('unknown').push(45);
 
 // The factory takes the name of the key and the current size of the map
-var map = new DefaultMap((key, size) => `${key}-${size}`);
+const map = new DefaultMap((key, size) => `${key}-${size}`);
 ```
 
 ## Members & Methods
@@ -91,7 +92,7 @@ The `DefaultMap` has the exact same interface as JavaScript's [`Map`](https://de
 Same as `#.get` except that it won't create a value using the provided factory if key is not found.
 
 ```js
-var map = new DefaultMap(() => []);
+const map = new DefaultMap(() => []);
 
 map.peek('one');
 >>> undefined
@@ -108,7 +109,7 @@ map.size
 A factory that will create a new incremental key for each unseen key.
 
 ```js
-var map = new DefaultMap(DefaultMap.autoIncrement());
+const map = new DefaultMap(DefaultMap.autoIncrement());
 
 map.get('unknown-one');
 >>> 0

--- a/fibonacci-heap.md
+++ b/fibonacci-heap.md
@@ -10,13 +10,13 @@ For more information about the Fibonacci heap, you can head [here](https://en.wi
 By default, the provided `FibonacciHeap` is a min heap and the `MaxFibonacciHeap` is just some sugar that will reverse the provided comparator for you.
 
 ```js
-var FibonacciHeap = require('mnemonist/fibonacci-heap');
+const FibonacciHeap = require('mnemonist/fibonacci-heap');
 // To access min/max fibonacci heap
-var MinFibonacciHeap = require('mnemonist/fibonacci-heap').MinFibonacciHeap;
-var MaxFibonacciHeap = require('mnemonist/fibonacci-heap').MaxFibonacciHeap;
+const { MinFibonacciHeap } = require('mnemonist/fibonacci-heap');
+const { MaxFibonacciHeap } = require('mnemonist/fibonacci-heap');
 
 // To create a heap:
-var heap = new FibonacciHeap();
+const heap = new FibonacciHeap();
 ```
 
 ## Constructor
@@ -25,7 +25,7 @@ The `FibonacciHeap` takes a single optional argument being the comparator functi
 
 ```js
 // Providing a comparator to handle custom objects
-var heap = new FibonacciHeap(function(a, b) {
+const heap = new FibonacciHeap((a, b) => {
   if (a.value < b.value)
     return -1;
   if (a.value > b.value)
@@ -45,7 +45,7 @@ heap.peek();
 Alternatively, one can build a `FibonacciHeap` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var heap = FibonacciHeap.from([1, 2, 3], comparator);
+const heap = FibonacciHeap.from([1, 2, 3], comparator);
 ```
 
 ## Members
@@ -69,7 +69,7 @@ var heap = FibonacciHeap.from([1, 2, 3], comparator);
 Number of items in the heap.
 
 ```js
-var heap = new FibonacciHeap();
+const heap = new FibonacciHeap();
 heap.size
 >>> 0
 ```
@@ -81,7 +81,7 @@ Pushes an item into the heap.
 `O(1)`
 
 ```js
-var heap = new FibonacciHeap();
+const heap = new FibonacciHeap();
 heap.push(34);
 ```
 
@@ -92,7 +92,7 @@ Retrieve & remove the min item of the heap (or the max item in case of a `MaxFib
 `O(log n)`
 
 ```js
-var heap = new FibonacciHeap();
+const heap = new FibonacciHeap();
 
 heap.push(4);
 heap.push(34);
@@ -110,7 +110,7 @@ heap.size
 Completely clears the heap.
 
 ```js
-var heap = new FibonacciHeap();
+const heap = new FibonacciHeap();
 
 heap.push(34);
 heap.clear();
@@ -125,7 +125,7 @@ Retrieves the min item of the heap (or the max item in case of a `MaxFibonacciHe
 `O(1)`
 
 ```js
-var heap = new FibonacciHeap();
+const heap = new FibonacciHeap();
 
 heap.push(4);
 heap.push(34);

--- a/fixed-deque.md
+++ b/fixed-deque.md
@@ -10,7 +10,7 @@ For more information about the deque, you can head [here](https://en.wikipedia.o
 Note that, contrary to the [`CircularBuffer`]({{ site.baseurl }}/circular-buffer), the `FixedDeque` will throw when overflowing capacity.
 
 ```js
-var FixedDeque = require('mnemonist/fixed-deque');
+const FixedDeque = require('mnemonist/fixed-deque');
 ```
 
 ## Constructor
@@ -18,10 +18,11 @@ var FixedDeque = require('mnemonist/fixed-deque');
 The `FixedDeque` takes two arguments: a array class to use, and the desired capacity.
 
 ```js
-var deque = new FixedDeque(Array, 10);
-
+const deque = new FixedDeque(Array, 10);
+```
+```js
 // Using byte arrays
-var deque = new FixedDeque(Int8Array, 10);
+const deque = new FixedDeque(Int8Array, 10);
 ```
 
 ### Static #.from
@@ -30,10 +31,11 @@ Alternatively, one can build a `FixedDeque` from an arbitrary JavaScript iterabl
 
 ```js
 // Attempting the guess the given iterable's length/size
-var deque = FixedDeque.from([1, 2, 3], Int8Array);
-
+const deque = FixedDeque.from([1, 2, 3], Int8Array);
+```
+```js
 // Providing the desired capacity
-var deque = FixedDeque.from([1, 2, 3], Int8Array, 10);
+const deque = FixedDeque.from([1, 2, 3], Int8Array, 10);
 ```
 
 ## Members
@@ -69,7 +71,7 @@ var deque = FixedDeque.from([1, 2, 3], Int8Array, 10);
 Maximum number of items the deque is able to store.
 
 ```js
-var deque = new FixedDeque(Array, 10);
+const deque = new FixedDeque(Array, 10);
 deque.capacity
 >>> 10
 ```
@@ -79,7 +81,7 @@ deque.capacity
 Number of items in the deque.
 
 ```js
-var deque = new FixedDeque(Array, 10);
+const deque = new FixedDeque(Array, 10);
 deque.size
 >>> 0
 ```
@@ -93,7 +95,7 @@ Will throw if the deque's capacity is exceeded.
 `O(1)`
 
 ```js
-var deque = new FixedDeque(Array, 10);
+const deque = new FixedDeque(Array, 10);
 
 deque.push(1);
 ```
@@ -107,7 +109,7 @@ Will throw if the deque's capacity is exceeded.
 `O(1)`
 
 ```js
-var deque = new FixedDeque(Array, 10);
+const deque = new FixedDeque(Array, 10);
 
 deque.unshift(1);
 ```
@@ -119,7 +121,7 @@ Retrieve & remove the last item of the deque.
 `O(1)`
 
 ```js
-var deque = new FixedDeque(Array, 10);
+const deque = new FixedDeque(Array, 10);
 
 deque.push(1);
 deque.push(2);
@@ -134,7 +136,7 @@ Retrieve & remove the first item of the deque.
 `O(1)`
 
 ```js
-var deque = new FixedDeque(Array, 10);
+const deque = new FixedDeque(Array, 10);
 
 deque.push(1);
 deque.push(2);
@@ -149,7 +151,7 @@ Completely clears the deque.
 `O(1)`
 
 ```js
-var deque = new FixedDeque(Array, 10);
+const deque = new FixedDeque(Array, 10);
 
 deque.push(1);
 deque.clear();
@@ -164,7 +166,7 @@ Retrieves the first item of the deque.
 `O(1)`
 
 ```js
-var deque = new FixedDeque(Array, 10);
+const deque = new FixedDeque(Array, 10);
 
 deque.push(1);
 deque.push(2);
@@ -179,7 +181,7 @@ Retrieves the last item of the deque.
 `O(1)`
 
 ```js
-var deque = new FixedDeque(Array, 10);
+const deque = new FixedDeque(Array, 10);
 
 deque.push(1);
 deque.push(2);
@@ -192,7 +194,7 @@ deque.peekLast();
 Iterates over the deque's values.
 
 ```js
-var deque = new FixedDeque(Array, 10);
+const deque = new FixedDeque(Array, 10);
 
 deque.push(1);
 deque.push(2);
@@ -209,7 +211,7 @@ Converts the deque into a JavaScript array.
 Note that the resulting array will be instantiated using the provided class.
 
 ```js
-var deque = new FixedDeque(Array, 10);
+const deque = new FixedDeque(Array, 10);
 
 deque.push(1);
 deque.push(2);
@@ -223,9 +225,9 @@ deque.toArray();
 Returns an iterator over the deque's values.
 
 ```js
-var deque = FixedDeque.from([1, 2, 3], Array);
+const deque = FixedDeque.from([1, 2, 3], Array);
 
-var iterator = deque.values();
+const iterator = deque.values();
 
 iterator.next().value
 >>> 1
@@ -236,9 +238,9 @@ iterator.next().value
 Returns an iterator over the deque's entries.
 
 ```js
-var deque = FixedDeque.from([1, 2, 3], Array);
+const deque = FixedDeque.from([1, 2, 3], Array);
 
-var iterator = deque.entries();
+const iterator = deque.entries();
 
 iterator.next().value
 >>> [0, 1]
@@ -249,9 +251,9 @@ iterator.next().value
 Alternatively, you can iterate over a deque's values using ES2015 `for...of` protocol:
 
 ```js
-var deque = FixedDeque.from([1, 2, 3], Array);
+const deque = FixedDeque.from([1, 2, 3], Array);
 
-for (var item of deque) {
+for (const item of deque) {
   console.log(item);
 }
 ```

--- a/fixed-deque.md
+++ b/fixed-deque.md
@@ -199,7 +199,7 @@ const deque = new FixedDeque(Array, 10);
 deque.push(1);
 deque.push(2);
 
-deque.forEach(function(item, index, deque) {
+deque.forEach((item, index, deque) => {
   console.log(index, item);
 });
 ```

--- a/fixed-reverse-heap.md
+++ b/fixed-reverse-heap.md
@@ -12,7 +12,7 @@ It is a "reverse" heap because internally, the heap will store the values you gi
 It is therefore impossible to pop or peek this heap and you can only push new values and consume the heap when the job is done.
 
 ```js
-var FixedReverseHeap = require('mnemonist/fixed-reverse-heap');
+const FixedReverseHeap = require('mnemonist/fixed-reverse-heap');
 ```
 
 ## Use case
@@ -22,9 +22,9 @@ Let's say we want to retrieve the 10 largest elements of a binary tree during a 
 Then the `FixedReverseHeap` is the right tool for the job.
 
 ```js
-var heap = new FixedReverseHeap(10);
+const heap = new FixedReverseHeap(10);
 
-var stack = [binaryTree.root],
+const stack = [binaryTree.root],
     node;
 
 while (stack.length) {
@@ -38,7 +38,7 @@ while (stack.length) {
 }
 
 // Consuming our heap to get our top 10
-var top10 = heap.consume();
+const top10 = heap.consume();
 ```
 
 Note that if you just want to retrieve the n largest/smallest values from an iterable, check the [nlargest]({{ site.baseurl }}/heap#nlargest) & [nsmallest]({{ site.baseurl }}/heap#nsmallest) functions from the [Heap]({{ site.baseurl }}/heap) module instead.
@@ -62,10 +62,10 @@ function compare(a, b) {
 }
 
 // Instantiating a heap that can store 15 items in a Uint8Array
-var heap = new FixedReverseHeap(Uint8Array, comparator, 15);
+const heap = new FixedReverseHeap(Uint8Array, comparator, 15);
 
 // Comparator can be omitted if you just want to compare numbers
-var heap = new FixedReverseHeap(Uint8Array, 15);
+const heap = new FixedReverseHeap(Uint8Array, 15);
 ```
 
 ## Members
@@ -91,7 +91,7 @@ var heap = new FixedReverseHeap(Uint8Array, 15);
 Maximum number of values that can be stored by the heap.
 
 ```js
-var heap = new FixedReverseHeap(Array, 3);
+const heap = new FixedReverseHeap(Array, 3);
 heap.capacity
 >>> 3
 ```
@@ -101,7 +101,7 @@ heap.capacity
 Number of values currently in the heap.
 
 ```js
-var heap = new FixedReverseHeap(Array, 3);
+const heap = new FixedReverseHeap(Array, 3);
 heap.size
 >>> 0
 ```
@@ -113,7 +113,7 @@ Pushes a value into the heap.
 `O(log n)`
 
 ```js
-var heap = new FixedReverseHeap(Array, 3);
+const heap = new FixedReverseHeap(Array, 3);
 heap.push(34);
 ```
 
@@ -122,7 +122,7 @@ heap.push(34);
 Fully consume the heap and return its items as a sorted array.
 
 ```js
-var heap = new FixedReverseHeap(Array, 3);
+const heap = new FixedReverseHeap(Array, 3);
 
 heap.push(45);
 heap.push(-3);
@@ -140,7 +140,7 @@ heap.size
 Completely clears the heap.
 
 ```js
-var heap = new FixedReverseHeap(Array, 3);
+const heap = new FixedReverseHeap(Array, 3);
 
 heap.push(34);
 heap.clear();
@@ -155,7 +155,7 @@ Returns the worst item currently stored in the heap.
 `O(1)`
 
 ```js
-var heap = new FixedReverseHeap(Array, 3);
+const heap = new FixedReverseHeap(Array, 3);
 
 heap.push(4);
 heap.push(34);
@@ -174,7 +174,7 @@ This method is mostly used for debugging purposes.
 `O(n log n)`
 
 ```js
-var heap = new FixedReverseHeap(Array, 3);
+const heap = new FixedReverseHeap(Array, 3);
 
 heap.push(4);
 heap.push(34);

--- a/fixed-stack.md
+++ b/fixed-stack.md
@@ -10,7 +10,7 @@ This means, however, that you must know beforehand the maximum size your stack w
 What's more, the `FixedStack` is able to rely on byte arrays and can therefore be very memory-efficient.
 
 ```js
-var FixedStack = require('mnemonist/fixed-stack');
+const FixedStack = require('mnemonist/fixed-stack');
 ```
 
 ## Constructor
@@ -18,10 +18,11 @@ var FixedStack = require('mnemonist/fixed-stack');
 The `FixedStack` takes two arguments: a array class to use, and the desired capacity.
 
 ```js
-var stack = new FixedStack(Array, 10);
-
+const stack = new FixedStack(Array, 10);
+```
+```js
 // Using byte arrays
-var stack = new FixedStack(Int8Array, 10);
+const stack = new FixedStack(Int8Array, 10);
 ```
 
 ### Static #.from
@@ -30,10 +31,11 @@ Alternatively, one can build a `FixedStack` from an arbitrary JavaScript iterabl
 
 ```js
 // Attempting the guess the given iterable's length/size
-var stack = FixedStack.from([1, 2, 3], Int8Array);
-
+const stack = FixedStack.from([1, 2, 3], Int8Array);
+```
+```js
 // Providing the desired capacity
-var stack = FixedStack.from([1, 2, 3], Int8Array, 10);
+const stack = FixedStack.from([1, 2, 3], Int8Array, 10);
 ```
 
 ## Members
@@ -66,7 +68,7 @@ var stack = FixedStack.from([1, 2, 3], Int8Array, 10);
 Maximum number of items the stack is able to store.
 
 ```js
-var stack = new FixedStack(Array, 10);
+const stack = new FixedStack(Array, 10);
 stack.capacity
 >>> 10
 ```
@@ -76,7 +78,7 @@ stack.capacity
 Number of items in the stack.
 
 ```js
-var stack = new FixedStack(Array, 10);
+const stack = new FixedStack(Array, 10);
 stack.size
 >>> 0
 ```
@@ -90,7 +92,7 @@ Will throw if the stack's capacity is exceeded.
 `O(1)`
 
 ```js
-var stack = new FixedStack(Array, 10);
+const stack = new FixedStack(Array, 10);
 
 stack.push(1);
 ```
@@ -102,7 +104,7 @@ Retrieve & remove the next item of the stack.
 `O(1)`
 
 ```js
-var stack = new FixedStack(Array, 10);
+const stack = new FixedStack(Array, 10);
 
 stack.push(1);
 stack.pop();
@@ -116,7 +118,7 @@ Completely clears the stack.
 `O(1)`
 
 ```js
-var stack = new FixedStack(Array, 10);
+const stack = new FixedStack(Array, 10);
 
 stack.push(1);
 stack.clear();
@@ -131,7 +133,7 @@ Retrieves the next item of the stack.
 `O(1)`
 
 ```js
-var stack = new FixedStack(Array, 10);
+const stack = new FixedStack(Array, 10);
 
 stack.push(1);
 stack.peek();
@@ -143,7 +145,7 @@ stack.peek();
 Iterates over the stack in LIFO order.
 
 ```js
-var stack = new FixedStack(Array, 10);
+const stack = new FixedStack(Array, 10);
 
 stack.push(1);
 stack.push(2);
@@ -160,7 +162,7 @@ Converts the stack into a LIFO JavaScript array.
 Note that the resulting array will be instantiated using the provided class.
 
 ```js
-var stack = new FixedStack(Array, 10);
+const stack = new FixedStack(Array, 10);
 
 stack.push(1);
 stack.push(2);
@@ -174,9 +176,9 @@ stack.toArray();
 Returns an iterator over the stack's values.
 
 ```js
-var stack = FixedStack.from([1, 2, 3], Array);
+const stack = FixedStack.from([1, 2, 3], Array);
 
-var iterator = stack.values();
+const iterator = stack.values();
 
 iterator.next().value
 >>> 3
@@ -187,9 +189,9 @@ iterator.next().value
 Returns an iterator over the stack's entries.
 
 ```js
-var stack = FixedStack.from([1, 2, 3], Array);
+const stack = FixedStack.from([1, 2, 3], Array);
 
-var iterator = stack.entries();
+const iterator = stack.entries();
 
 iterator.next().value
 >>> [0, 3]
@@ -200,9 +202,9 @@ iterator.next().value
 Alternatively, you can iterate over a stack's values using ES2015 `for...of` protocol:
 
 ```js
-var stack = FixedStack.from([1, 2, 3], Array);
+const stack = FixedStack.from([1, 2, 3], Array);
 
-for (var item of stack) {
+for (const item of stack) {
   console.log(item);
 }
 ```

--- a/fixed-stack.md
+++ b/fixed-stack.md
@@ -150,7 +150,7 @@ const stack = new FixedStack(Array, 10);
 stack.push(1);
 stack.push(2);
 
-stack.forEach(function(item, index, stack) {
+stack.forEach((item, index, stack) => {
   console.log(index, item);
 });
 ```

--- a/fuzzy-map.md
+++ b/fuzzy-map.md
@@ -6,7 +6,7 @@ title: Fuzzy Map
 The `FuzzyMap` is a map whoses keys are transformed by a function before any read or write operation. This can often result in multiple keys being able to access the same resource.
 
 ```js
-var FuzzyMap = require('mnemonist/fuzzy-map');
+const FuzzyMap = require('mnemonist/fuzzy-map');
 ```
 
 ## Use case
@@ -14,36 +14,32 @@ var FuzzyMap = require('mnemonist/fuzzy-map');
 Let's say we want to store & query objects representing movies based on their lowercased title. One approach would be to create a JavaScript object & lowercase the correct movies' property to use as key:
 
 ```js
-var movie = {
+const movie = {
   name: 'Great Movie',
   year: 1999
 };
 
-var object = {};
+const object = {};
 
 // Let's insert our movie using the lowercased title as key
-var key = movie.name.toLowerCase();
+const key = movie.name.toLowerCase();
 object[key] = movie;
 
 // Now, to query:
-var query = 'great MoVie';
+const query = 'great MoVie';
 console.log(object[query.toLowerCase()]);
 ```
 
 That's it, you have understood the `FuzzyMap`. It's just some sugar over a JavaScript `Map` that will transform the given keys using a custom function to perform this kind of operations easily.
 
 ```js
-var map = new FuzzyMap([
+const map = new FuzzyMap([
   
   // Hash function on add
-  function(movie) {
-    return movie.title.toLowerCase();
-  },
+  (movie) => movie.title.toLowerCase(),
 
   // Hash function on query
-  function(query) {
-    return query.toLowerCase();
-  }
+  (query) => query.toLowerCase(),
 ]);
 
 // FuzzyMaping several movies
@@ -68,9 +64,7 @@ The `FuzzyMap` either takes a single argument being a hash function that will pr
 
 ```js
 // Let's create an map using a single hash function:
-var map = new FuzzyMap(function(value) {
-  return value.toUpperCase();
-});
+const map = new FuzzyMap((value) => value.toUpperCase());
 
 // Then you'll probably use #.set to insert items
 map.set(movie.title, movie);
@@ -81,17 +75,13 @@ map.get(queryTitle);
 
 ```js
 // Let's create an map using two different hash functions:
-var map = new FuzzyMap([
+const map = new FuzzyMap([
   
   // Hash function for inserted items:
-  function(movie) {
-    return movie.title.toLowerCase();
-  },
+  movie => movie.title.toLowerCase(),
 
   // Hash function for queries
-  function(query) {
-    return query.toLowerCase();
-  }
+  (query) => query.toLowerCase(),
 ]);
 
 // Then you'll probably use #.add to insert items
@@ -102,11 +92,9 @@ map.get(queryTitle);
 **Warning!**: the map will not consider any falsy key processed by its hash functions.
 
 ```js
-var map = new FuzzyMap(function(item) {
-  return item.title && item.title.toLowerCase();
-});
+const map = new FuzzyMap((item) => item.title && item.title.toLowerCase());
 
-var movie = {year: 1999};
+const movie = {year: 1999};
 
 // This will not be indexed on `undefined`
 map.set(movie.title, movie);
@@ -117,8 +105,8 @@ map.set(movie.title, movie);
 Alternatively, one can build a `FuzzyMap` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var map = FuzzyMap.from(list, hashFunction [, useSet=false]);
-var map = FuzzyMap.from(list, hashFunctions [, useSet=false]);
+const map = FuzzyMap.from(list, hashFunction [, useSet=false]);
+const map = FuzzyMap.from(list, hashFunctions [, useSet=false]);
 ```
 
 ## Members
@@ -149,7 +137,7 @@ var map = FuzzyMap.from(list, hashFunctions [, useSet=false]);
 Number of items stored in the map.
 
 ```js
-var map = new FuzzyMap();
+const map = new FuzzyMap();
 map.add({title: 'Hello World!'});
 
 map.size
@@ -163,12 +151,12 @@ Computes the item's key by hashing the given item using the relevant function th
 `O(1)`
 
 ```js
-var map = new FuzzyMap();
+const map = new FuzzyMap();
 
 map.add({title: 'Great movie', year: 1999});
 
 // In fact, same as doing
-var movie = {title: 'Great movie', year: 1999};
+const movie = {title: 'Great movie', year: 1999};
 map.set(movie, movie);
 ```
 
@@ -179,8 +167,8 @@ Adds an item to the map using the provided key that will be processed by the rel
 `O(1)`
 
 ```js
-var map = new FuzzyMap();
-var movie = {title: 'Great movie', year: 1999};
+const map = new FuzzyMap();
+const movie = {title: 'Great movie', year: 1999};
 
 map.set(movie.title, movie);
 ```
@@ -190,7 +178,7 @@ map.set(movie.title, movie);
 Completely clears the map of its items.
 
 ```js
-var map = new FuzzyMap();
+const map = new FuzzyMap();
 map.add(item);
 map.clear();
 
@@ -205,9 +193,7 @@ Retrieves an item in the map using the provided key that will be processed by th
 `O(1)`
 
 ```js
-var map = new FuzzyMap(function(string) {
-  return string.toLowerCase();
-});
+const map = new FuzzyMap((string) => string.toLowerCase());
 map.set('hello world', {name: 'hello world'});
 map.get('Hello World');
 >>> {name: 'hello world'}
@@ -220,9 +206,7 @@ Test whether the provided key, processed by the relevant hash function, would re
 `O(1)`
 
 ```js
-var map = new FuzzyMap(function(string) {
-  return string.toLowerCase();
-});
+const map = new FuzzyMap((string) => string.toLowerCase());
 map.set('hello world', {name: 'hello world'});
 map.has('Hello World');
 >>> true
@@ -233,15 +217,13 @@ map.has('Hello World');
 Iterates over the values stored in the map.
 
 ```js
-var map = new FuzzyMap(function(string) {
-  return string.toLowerCase();
-});
+const map = new FuzzyMap((string) => string.toLowerCase());
 
 map.set('Hello', {name: 'hello'});
 map.set('World', {name: 'world'});
 
-map.forEach(function(value) {
-  console.log(value);
+map.forEach((value) => {
+  console.log(value)
 });
 >>> {name: 'hello'}
 >>> {name: 'world'}
@@ -252,14 +234,12 @@ map.forEach(function(value) {
 Creates an iterator over the map's values.
 
 ```js
-var map = new FuzzyMap(function(string) {
-  return string.toLowerCase();
-});
+const map = new FuzzyMap((string) => string.toLowerCase());
 
 map.set('Hello', {name: 'hello'});
 map.set('World', {name: 'world'});
 
-var iterator = map.values();
+const iterator = map.values();
 iterator.next().value();
 >>> {name: 'hello'}
 ```
@@ -269,14 +249,12 @@ iterator.next().value();
 Alternatively, you can iterate over an map' values using ES2015 `for...of` protocol:
 
 ```js
-var map = new FuzzyMap(function(string) {
-  return string.toLowerCase();
-});
+const map = new FuzzyMap((string) => string.toLowerCase());
 
 map.set('Hello', {name: 'hello'});
 map.set('World', {name: 'world'});
 
-for (var value of map) {
+for (const value of map) {
   console.log(value);
 }
 ```

--- a/fuzzy-multi-map.md
+++ b/fuzzy-multi-map.md
@@ -100,8 +100,10 @@ map.set(movie.title, movie);
 Alternatively, one can build a `FuzzyMultiMap` from an arbitrary JavaScript iterable likewise:
 
 ```js
-const map = FuzzyMultiMap.from(list, hashFunction [, useSet=false]);
-const map = FuzzyMultiMap.from(list, hashFunction [, Container, useSet=false]);
+const map = FuzzyMultiMap.from(list, hashFunctions);
+```
+```js
+const map = FuzzyMultiMap.from(list, hashFunctions, Container);
 ```
 
 ## Members

--- a/fuzzy-multi-map.md
+++ b/fuzzy-multi-map.md
@@ -6,7 +6,7 @@ title: Fuzzy MultiMap
 The `FuzzyMultiMap` is basically a [`FuzzyMap`]({{ site.baseurl }}/fuzzy-map) that accepts more than one value per key and stores the colliding items in buckets.
 
 ```js
-var FuzzyMultiMap = require('mnemonist/fuzzy-multi-map');
+const FuzzyMultiMap = require('mnemonist/fuzzy-multi-map');
 ```
 
 ## Use case
@@ -22,17 +22,17 @@ function fuzzyTitle(title) {
 }
 
 // Creating our index
-var map = new FuzzyMultiMap(fuzzyTitle);
+const map = new FuzzyMultiMap(fuzzyTitle);
 
 // Adding some universities
-var universities = [
+const universities = [
   {name: 'University of Carolina'},
   {name: 'Carolina, university of.'},
   {name: 'Harvard university'}
 ];
 
-universities.forEach(function(university) {
-  map.set(university.name, university);
+universities.forEach((university) => {
+  map.set(university.name, university)
 });
 
 // Now we can query the index
@@ -53,9 +53,7 @@ As with the [MultiMap]({{ site.baseurl }}/multi-map), the `FuzzyMultiMap` can al
 
 ```js
 // Let's create an index using a single hash function:
-var map = new FuzzyMultiMap(function(value) {
-  return value.toUpperCase();
-});
+const map = new FuzzyMultiMap((value) => value.toUpperCase());
 
 // Then you'll probably use #.set to insert items
 map.set(movie.title, movie);
@@ -66,17 +64,13 @@ map.get(queryTitle);
 
 ```js
 // Let's create an index using two different hash functions:
-var map = new FuzzyMultiMap([
+const map = new FuzzyMultiMap([
   
   // Hash function for inserted items:
-  function(movie) {
-    return movie.title.toLowerCase();
-  },
+  (movie) => movie.title.toLowerCase(),
 
   // Hash function for queries
-  function(query) {
-    return query.toLowerCase();
-  }
+  (query) => query.toLowerCase(),
 ]);
 
 // Then you'll probably use #.add to insert items
@@ -87,19 +81,15 @@ map.get(queryTitle);
 *Example with Set containers*
 
 ```js
-var map = new FuzzyMultiMap(function(value) {
-  return value.toUpperCase(); 
-}, Set);
+const map = new FuzzyMultiMap((value) => value.toUpperCase(), Set);
 ```
 
 **Warning!**: the index will not consider any falsy key processed by its hash functions.
 
 ```js
-var map = new FuzzyMultiMap(function(item) {
-  return item.title && item.title.toLowerCase();
-});
+const map = new FuzzyMultiMap((item) => item.title && item.title.toLowerCase());
 
-var movie = {year: 1999};
+const movie = {year: 1999};
 
 // This will not be indexed on `undefined`
 map.set(movie.title, movie);
@@ -110,8 +100,8 @@ map.set(movie.title, movie);
 Alternatively, one can build a `FuzzyMultiMap` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var map = FuzzyMultiMap.from(list, hashFunction [, useSet=false]);
-var map = FuzzyMultiMap.from(list, hashFunction [, Container, useSet=false]);
+const map = FuzzyMultiMap.from(list, hashFunction [, useSet=false]);
+const map = FuzzyMultiMap.from(list, hashFunction [, Container, useSet=false]);
 ```
 
 ## Members
@@ -143,7 +133,7 @@ var map = FuzzyMultiMap.from(list, hashFunction [, Container, useSet=false]);
 Number of item containers stored in the map.
 
 ```js
-var map = new FuzzyMultiMap();
+const map = new FuzzyMultiMap();
 map.set('hello', 3);
 map.set('hello', 4);
 
@@ -158,7 +148,7 @@ map.dimension
 Number of items stored in the map.
 
 ```js
-var map = new FuzzyMultiMap();
+const map = new FuzzyMultiMap();
 map.add({title: 'Hello World!'});
 
 map.size
@@ -172,12 +162,12 @@ Computes the item's key by hashing the given item using the relevant function th
 `O(1)`
 
 ```js
-var map = new FuzzyMultiMap();
+const map = new FuzzyMultiMap();
 
 map.add({title: 'Great movie', year: 1999});
 
 // In fact, same as doing
-var movie = {title: 'Great movie', year: 1999};
+const movie = {title: 'Great movie', year: 1999};
 map.set(movie, movie);
 ```
 
@@ -188,8 +178,8 @@ Adds an item to the map using the provided key that will be processed by the rel
 `O(1)`
 
 ```js
-var map = new FuzzyMultiMap();
-var movie = {title: 'Great movie', year: 1999};
+const map = new FuzzyMultiMap();
+const movie = {title: 'Great movie', year: 1999};
 
 map.set(movie.title, movie);
 ```
@@ -199,7 +189,7 @@ map.set(movie.title, movie);
 Completely clears the map of its items.
 
 ```js
-var map = new FuzzyMultiMap();
+const map = new FuzzyMultiMap();
 map.add(item);
 map.clear();
 
@@ -214,9 +204,7 @@ Hash the given key using the relevant function then returns the set of items sto
 `O(1)`
 
 ```js
-var map = new FuzzyMultiMap(function(string) {
-  return string.toLowerCase();
-});
+const map = new FuzzyMultiMap((string) => string.toLowerCase());
 map.set('John', {name: 'John', surname: 'Williams'});
 map.set('John', {name: 'John', surname: 'Ableton'});
 
@@ -234,9 +222,7 @@ Test whether the provided key, processed by the relevant hash function, would re
 `O(1)`
 
 ```js
-var map = new FuzzyMultiMap(function(string) {
-  return string.toLowerCase();
-});
+const map = new FuzzyMultiMap((string) => string.toLowerCase());
 map.set('John', {name: 'John', surname: 'Williams'});
 map.set('John', {name: 'John', surname: 'Ableton'});
 
@@ -249,14 +235,12 @@ map.get('john');
 Iterates over the values stored in the map.
 
 ```js
-var map = new FuzzyMultiMap(function(string) {
-  return string.toLowerCase();
-});
+const map = new FuzzyMultiMap((string) => string.toLowerCase());
 
 map.set('John', {name: 'John', surname: 'Williams'});
 map.set('John', {name: 'John', surname: 'Ableton'});
 
-map.forEach(function(value) {
+map.forEach((value) => {
   console.log(value);
 });
 >>> {name: 'John', surname: 'Williams'}
@@ -268,14 +252,12 @@ map.forEach(function(value) {
 Creates an iterator over the map's values.
 
 ```js
-var map = new FuzzyMultiMap(function(string) {
-  return string.toLowerCase();
-});
+const map = new FuzzyMultiMap((string) => string.toLowerCase());
 
 map.set('John', {name: 'John', surname: 'Williams'});
 map.set('John', {name: 'John', surname: 'Ableton'});
 
-var iterator = map.values();
+const iterator = map.values();
 iterator.next().value();
 >>> {name: 'John', surname: 'Williams'}
 ```
@@ -285,14 +267,12 @@ iterator.next().value();
 Alternatively, you can iterate over an map' values using ES2015 `for...of` protocol:
 
 ```js
-var map = new FuzzyMultiMap(function(string) {
-  return string.toLowerCase();
-});
+const map = new FuzzyMultiMap((string) => string.toLowerCase());
 
 map.set('John', {name: 'John', surname: 'Williams'});
 map.set('John', {name: 'John', surname: 'Ableton'});
 
-for (var value of map) {
+for (const  value of map) {
   console.log(value);
 }
 ```

--- a/generalized-suffix-array.md
+++ b/generalized-suffix-array.md
@@ -10,7 +10,7 @@ Its main use is to be able to compute the longest common subsequence of the inpu
 For more information about the Generalized Suffix Array, you can head [here](https://en.wikipedia.org/wiki/Suffix_array).
 
 ```js
-var GeneralizedSuffixArray = require('mnemonist/suffix-array').GeneralizedSuffixArray;
+const { GeneralizedSuffixArray } = require('mnemonist/suffix-array');
 ```
 
 ## Constructor
@@ -18,13 +18,13 @@ var GeneralizedSuffixArray = require('mnemonist/suffix-array').GeneralizedSuffix
 The `GeneralizedSuffixArray` class simply takes an array of strings or an array of arbitrary arrays of string tokens as its only argument:
 
 ```js
-var suffixArray = new GeneralizedSuffixArray([
+const suffixArray = new GeneralizedSuffixArray([
   'banana',
   'ananas'
 ]);
 
 // Also works with arbitrary sequences of tokens
-var suffixArray = new GeneralizedSuffixArray([
+const suffixArray = new GeneralizedSuffixArray([
   ['the', 'cat', 'eats', 'the', 'mouse'],
   ['the', 'mouse', 'eats', 'cheese']
 ]);
@@ -47,7 +47,7 @@ Note that if you pass an array of arbitrary arrays of tokens, computation time f
 The computed suffix array.
 
 ```js
-var suffixArray = new GeneralizedSuffixArray(['banana', 'ananas']);
+const suffixArray = new GeneralizedSuffixArray(['banana', 'ananas']);
 suffixArray.array
 >>> [6, 5, 3, 1, 7, 9, 11, 0, 4, 2, 8, 10, 12]
 ```
@@ -57,7 +57,7 @@ suffixArray.array
 The length of the array.
 
 ```js
-var suffixArray = new GeneralizedSuffixArray(['banana', 'ananas']);
+const suffixArray = new GeneralizedSuffixArray(['banana', 'ananas']);
 suffixArray.length
 >>> 13
 ```
@@ -67,7 +67,7 @@ suffixArray.length
 The number of elements stored.
 
 ```js
-var suffixArray = new GeneralizedSuffixArray(['banana', 'ananas']);
+const suffixArray = new GeneralizedSuffixArray(['banana', 'ananas']);
 suffixArray.size
 >>> 2
 ```
@@ -79,12 +79,13 @@ Retrieves the longest common subsequence of the array.
 `O(n)`
 
 ```js
-var suffixArray = new GeneralizedSuffixArray(['banana', 'ananas']);
+const suffixArray = new GeneralizedSuffixArray(['banana', 'ananas']);
 
 suffixArray.longestCommonSubsequence();
 >>> 'anana'
-
-var suffixArray = new GeneralizedSuffixArray([
+```
+```js
+const suffixArray = new GeneralizedSuffixArray([
   ['the', 'cat', 'eats', 'the', 'mouse'],
   ['the', 'mouse', 'eats', 'cheese']
 ]);

--- a/hashed-array-tree.md
+++ b/hashed-array-tree.md
@@ -6,7 +6,7 @@ title: HashedArrayTree
 The `HashedArrayTree` is an abstract class representing a JavaScript typed array, such as the `Int32Array`, but able to grow dynamically.
 
 ```js
-var HashedArrayTree = require('mnemonist/hashed-array-tree');
+const HashedArrayTree = require('mnemonist/hashed-array-tree');
 ```
 
 ## Constructor
@@ -14,10 +14,11 @@ var HashedArrayTree = require('mnemonist/hashed-array-tree');
 The `HashedArrayTree` takes a typed array class as first argument and an initial length or alternatively more complex options as second argument.
 
 ```js
-var array = new HashedArrayTree(ArrayClass, initialCapacity);
-
+const array = new HashedArrayTree(ArrayClass, initialCapacity);
+```
+```js
 // If you need to pass options such as a custom block size
-var array = new HashedArrayTree(ArrayClass, {
+const array = new HashedArrayTree(ArrayClass, {
   initialCapacity: 10,
   initialLength: 3,
   blockSize: 8 // Defaults to 1024. Must be a power of two!
@@ -49,7 +50,7 @@ var array = new HashedArrayTree(ArrayClass, {
 Size of the byte array blocks.
 
 ```js
-var array = new HashedArrayTree(Uint8Array);
+const array = new HashedArrayTree(Uint8Array);
 
 array.blockSize;
 >>> 1024
@@ -60,7 +61,7 @@ array.blockSize;
 Number of items the array can accomodate without needing to add further blocks.
 
 ```js
-var array = new HashedArrayTree(Uint8Array);
+const array = new HashedArrayTree(Uint8Array);
 
 array.push(1);
 array.push(2);
@@ -74,7 +75,7 @@ array.capacity
 Current length of the array, that is to say the last set index plus one.
 
 ```js
-var array = new HashedArrayTree(Uint8Array);
+const array = new HashedArrayTree(Uint8Array);
 
 array.push(1);
 array.push(2);
@@ -90,7 +91,7 @@ Add a single block to the array.
 If given a number, will add as many new blocks as needed to accomodate target capacity.
 
 ```js
-var array = new HashedArrayTree(Uint8Array, {blockSize: 8});
+const array = new HashedArrayTree(Uint8Array, {blockSize: 8});
 
 array.grow();
 array.capacity;
@@ -109,7 +110,7 @@ Sets the value at the given index.
 `O(1)`
 
 ```js
-var array = new HashedArrayTree(Uint8Array, 2);
+const array = new HashedArrayTree(Uint8Array, 2);
 
 array.set(1, 45);
 
@@ -124,7 +125,7 @@ Removes & returns the last value of the array.
 `O(1)`
 
 ```js
-var array = new HashedArrayTree(Uint8Array);
+const array = new HashedArrayTree(Uint8Array);
 
 array.push(1);
 array.push(2);
@@ -143,7 +144,7 @@ Pushes a new value in the array.
 `O(1) amortized`
 
 ```js
-var array = new HashedArrayTree(Uint8Array);
+const array = new HashedArrayTree(Uint8Array);
 
 array.push(1);
 array.push(2);
@@ -164,7 +165,7 @@ Resize the array's length. Will add new blocks if current blocks are insufficien
 Note that it won't deallocate anything would the given length be inferior to the current one.
 
 ```js
-var array = new HashedArrayTree(Uint8Array, {initialLength: 10, blockSize: 8});
+const array = new HashedArrayTree(Uint8Array, {initialLength: 10, blockSize: 8});
 
 array.resize(5);
 array.length;
@@ -187,7 +188,7 @@ Retrieves the value stored at the given index.
 `O(1)`
 
 ```js
-var array = new HashedArrayTree(Uint8Array);
+const array = new HashedArrayTree(Uint8Array);
 
 array.push(1);
 array.push(2);

--- a/heap.md
+++ b/heap.md
@@ -10,11 +10,11 @@ For more information about the Heap, you can head [here](https://en.wikipedia.or
 By default, the provided `Heap` is a min heap and the `MaxHeap` is just some sugar that will reverse the provided comparator for you.
 
 ```js
-var Heap = require('mnemonist/heap');
+const Heap = require('mnemonist/heap');
 
 // To access min/max heap
-var MinHeap = require('mnemonist/heap').MinHeap;
-var MaxHeap = require('mnemonist/heap').MaxHeap;
+const { MinHeap } = require('mnemonist/heap');
+const { MaxHeap } = require('mnemonist/heap');
 ```
 
 If you know the maximum number of items you will store and need a more performant implementation, check out the [`FixedReverseHeap`]({{ site.baseurl }}/fixed-reverse-heap).
@@ -28,7 +28,7 @@ In such cases, a `Heap` can help you tremendously by keeping the items you give 
 ```js
 // Let's give a comparator function to our Heap
 // to be able to tell which tasks are the most urgent
-var heap = new Heap(function(a, b) {
+const heap = new Heap((a, b) => {
   if (a.priority > b.priority)
     return -1;
   if (a.priority < b.priority)
@@ -47,7 +47,7 @@ heap.peek().task;
 
 // Let's perform our tasks
 while (heap.size) {
-  var task = heap.pop().task;
+  const task = heap.pop().task;
   console.log('Doing:', task);
 }
 ```
@@ -58,7 +58,7 @@ The `Heap` takes a single optional argument being the comparator function to be 
 
 ```js
 // Providing a comparator to handle custom objects
-var heap = new Heap(function(a, b) {
+const heap = new Heap((a, b) => {
   if (a.value < b.value)
     return -1;
   if (a.value > b.value)
@@ -78,7 +78,7 @@ heap.peek();
 Alternatively, one can build a `Heap` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var heap = Heap.from([1, 2, 3], comparator);
+const heap = Heap.from([1, 2, 3], comparator);
 ```
 
 The construction is done in linear time.
@@ -124,7 +124,7 @@ If you need to find the n smallest/largest elements from arbitrary iterables eff
 Number of items in the heap.
 
 ```js
-var heap = new Heap();
+const heap = new Heap();
 heap.size
 >>> 0
 ```
@@ -136,7 +136,7 @@ Pushes an item into the heap.
 `O(log n)`
 
 ```js
-var heap = new Heap();
+const heap = new Heap();
 heap.push(34);
 ```
 
@@ -147,7 +147,7 @@ Retrieve & remove the min item of the heap (or the max item in case of a `MaxHea
 `O(log n)`
 
 ```js
-var heap = new Heap();
+const heap = new Heap();
 
 heap.push(4);
 heap.push(34);
@@ -171,7 +171,7 @@ This is more efficient than doing `pop` then `push` and does not change the leng
 `O(log n)`
 
 ```js
-var heap = new Heap();
+const heap = new Heap();
 
 heap.push(1);
 heap.replace(2);
@@ -193,7 +193,7 @@ This is more efficient than doing `push` than `pop` and does not change the leng
 `O(log n)`
 
 ```js
-var heap = new Heap();
+const heap = new Heap();
 
 heap.push(1);
 heap.pushpop(2);
@@ -211,7 +211,7 @@ heap.pop();
 Fully consume the heap and return its items as a sorted array.
 
 ```js
-var heap = new Heap();
+const heap = new Heap();
 
 heap.push(45);
 heap.push(-3);
@@ -229,7 +229,7 @@ heap.size
 Completely clears the heap.
 
 ```js
-var heap = new Heap();
+const heap = new Heap();
 
 heap.push(34);
 heap.clear();
@@ -244,7 +244,7 @@ Retrieves the min item of the heap (or the max item in case of a `MaxHeap`).
 `O(1)`
 
 ```js
-var heap = new Heap();
+const heap = new Heap();
 
 heap.push(4);
 heap.push(34);
@@ -263,7 +263,7 @@ This method is mostly used for debugging purposes.
 `O(n log n)`
 
 ```js
-var heap = new Heap();
+const heap = new Heap();
 
 heap.push(4);
 heap.push(34);
@@ -284,7 +284,7 @@ Converts the given array into a heap in linear time.
 `O(n)`
 
 ```js
-var array = [4, 1, -5, 10];
+const array = [4, 1, -5, 10];
 
 Heap.heapify(comparator, array);
 // You array has been heapified!
@@ -297,7 +297,7 @@ Push a new item into the heap.
 `O(log n)`
 
 ```js
-var array = [];
+const array = [];
 
 Heap.push(comparator, array, 4);
 Heap.push(comparator, array, 3);
@@ -314,7 +314,7 @@ Pop the heap.
 `O(log n)`
 
 ```js
-var array = [];
+const array = [];
 
 Heap.push(comparator, array, 4);
 Heap.push(comparator, array, 3);
@@ -335,7 +335,7 @@ This is more efficient than doing `pop` then `push` and does not change the leng
 `O(log n)`
 
 ```js
-var array = [];
+const array = [];
 
 Heap.push(comparator, array, 1);
 Heap.replace(comparator, array, 2);
@@ -358,7 +358,7 @@ This is more efficient than doing `push` than `pop` and does not change the leng
 `O(log n)`
 
 ```js
-var array = [];
+const array = [];
 
 Heap.push(comparator, array, 1);
 Heap.pushpop(comparator, array, 2);
@@ -378,7 +378,7 @@ Completely consumes the heap and returns all its items in a sorted array.
 `O(n log n)`
 
 ```js
-var array = [4, 1, 3];
+const array = [4, 1, 3];
 
 Heap.heapify(comparator, array);
 Heap.consume(comparator, array);

--- a/inverted-index.md
+++ b/inverted-index.md
@@ -57,9 +57,7 @@ The `InvertedIndex` either takes a single argument being a tokenizer function th
 
 ```js
 // Let's create an index using a single hash function:
-const index = new InvertedIndex(function(value) {
-  return words(value);
-});
+const index = new InvertedIndex((value) => words(value));
 
 index.add('The mouse likes cheese.');
 index.query('cheese');
@@ -72,14 +70,10 @@ index.query('cheese');
 const index = new Index([
   
   // Tokenizer function for inserted documents:
-  function(doc) {
-    return words(doc.text);
-  },
+  (doc) => words(doc.text),
 
   // Tokenizer function for queries
-  function(query) {
-    return words(query);
-  }
+  (query) => words(query),
 ]);
 
 // Then you'll probably use #.add to insert items
@@ -207,7 +201,7 @@ const index = new InvertedIndex(words);
 index.add('The cat eats the mouse.');
 index.add('The mouse eats cheese.');
 
-index.forEach(function(doc) {
+index.forEach((doc) => {
   console.log(doc);
 });
 ```

--- a/inverted-index.md
+++ b/inverted-index.md
@@ -6,7 +6,7 @@ title: Inverted Index
 An `InvertedIndex` is an index that considers the inserted documents as a set of tokens that are all keys that one can use to retrieve the documents.
 
 ```js
-var InvertedIndex = require('mnemonist/inverted-index');
+const InvertedIndex = require('mnemonist/inverted-index');
 ```
 
 ## Use case
@@ -22,16 +22,16 @@ Let's see how we could search for documents using a very naive word tokenizer:
 
 ```js
 // The `words` function from lodash is pretty good, for instance
-var words = require('lodash/words');
+const words = require('lodash/words');
 
-var documents = [
+const documents = [
   'The mouse is a gentle animal',
   'The cats eats the mouse',
   'The mouse eats cheese'
 ];
 
 // Creating our inverted index with our `words` tokenizer function
-var index = new InvertedIndex(words);
+const index = new InvertedIndex(words);
 
 // Now we can query it
 index.get('mouse');
@@ -57,7 +57,7 @@ The `InvertedIndex` either takes a single argument being a tokenizer function th
 
 ```js
 // Let's create an index using a single hash function:
-var index = new InvertedIndex(function(value) {
+const index = new InvertedIndex(function(value) {
   return words(value);
 });
 
@@ -69,7 +69,7 @@ index.query('cheese');
 
 ```js
 // Let's create an index using two different hash functions:
-var index = new Index([
+const index = new Index([
   
   // Tokenizer function for inserted documents:
   function(doc) {
@@ -92,8 +92,10 @@ index.query('mouse');
 Alternatively, one can build an `InvertedIndex` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var index = InvertedIndex.from(list, tokenizer);
-var index = InvertedIndex.from(list, tokenizers);
+const index = InvertedIndex.from(list, tokenizer);
+```
+```js
+const index = InvertedIndex.from(list, tokenizers);
 ```
 
 ## Members
@@ -124,7 +126,7 @@ var index = InvertedIndex.from(list, tokenizers);
 Number of documents stored in the index.
 
 ```js
-var index = new InvertedIndex(words);
+const index = new InvertedIndex(words);
 
 index.add('The cat eats the mouse.');
 
@@ -137,7 +139,7 @@ index.size
 Number of distinct tokens stored in the index (size of the dictionary, if you will).
 
 ```js
-var index = new InvertedIndex(words);
+const index = new InvertedIndex(words);
 
 index.add('The cat eats the mouse.');
 
@@ -152,7 +154,7 @@ Tokenize the given document using the relevant function and adds it to the index
 `O(t)`, t being the number of tokens.
 
 ```js
-var index = new InvertedIndex(words);
+const index = new InvertedIndex(words);
 
 index.add('The cat eats the mouse.');
 ```
@@ -162,7 +164,7 @@ index.add('The cat eats the mouse.');
 Completely clears the index of its documents.
 
 ```js
-var index = new InvertedIndex(words);
+const index = new InvertedIndex(words);
 
 index.add('The cat eats the mouse.');
 index.clear();
@@ -178,7 +180,7 @@ Tokenize the query using the relevant function, then retrieves the intersection 
 `O(t)`, t being the number of tokens.
 
 ```js
-var index = new InvertedIndex(words);
+const index = new InvertedIndex(words);
 
 index.add('The cat eats the mouse.');
 index.add('The mouse eats cheese.');
@@ -200,7 +202,7 @@ index.get('cat mouse');
 Iterates over the index by applying the callback to every stored document.
 
 ```js
-var index = new InvertedIndex(words);
+const index = new InvertedIndex(words);
 
 index.add('The cat eats the mouse.');
 index.add('The mouse eats cheese.');
@@ -215,12 +217,12 @@ index.forEach(function(doc) {
 Returns an iterator over the index's documents.
 
 ```js
-var index = new InvertedIndex(words);
+const index = new InvertedIndex(words);
 
 index.add('The cat eats the mouse.');
 index.add('The mouse eats cheese.');
 
-var iterator = index.documents();
+const iterator = index.documents();
 
 iteraror.next().value
 >>> 'The cat eats the mouse.'
@@ -231,12 +233,12 @@ iteraror.next().value
 Returns an iterator over the index's tokens.
 
 ```js
-var index = new InvertedIndex(words);
+const index = new InvertedIndex(words);
 
 index.add('The cat eats the mouse.');
 index.add('The mouse eats cheese.');
 
-var iterator = index.tokens();
+const iterator = index.tokens();
 
 iterator.next().value
 >>> 'The'
@@ -247,12 +249,12 @@ iterator.next().value
 Alternatively, you can iterate over an index's documents using ES2015 `for...of` protocol:
 
 ```js
-var index = new InvertedIndex(words);
+const index = new InvertedIndex(words);
 
 index.add('The cat eats the mouse.');
 index.add('The mouse eats cheese.');
 
-for (var doc of index) {
+for (const doc of index) {
   console.log(doc);
 }
 ```

--- a/kd-tree.md
+++ b/kd-tree.md
@@ -8,7 +8,7 @@ A `KDTree`, or k-dimensional tree, is a data structure used to index points in a
 For more information about the `KDTree`, you can head [here](https://en.wikipedia.org/wiki/K-d_tree).
 
 ```js
-var KDTree = require('mnemonist/kd-tree');
+const KDTree = require('mnemonist/kd-tree');
 ```
 
 ## Constructor
@@ -26,7 +26,7 @@ A `KDTree` can be built from an iterable yielding items looking like this:
 ```
 
 ```js
-var data = [
+const data = [
   ['zero', [2, 3]],
   ['one', [5, 4]],
   ['two', [9, 6]],
@@ -35,7 +35,7 @@ var data = [
   ['five', [7, 2]]
 ];
 
-var tree = KDTree.from(data, 2);
+const tree = KDTree.from(data, 2);
 ```
 
 ### Static #.fromAxes
@@ -43,16 +43,16 @@ var tree = KDTree.from(data, 2);
 For better memory efficiency, or just because you organized your data thusly, you can also build a `KDTree` from axes with optional labels. If you don't provide labels, the tree will simply return indices to you when querying.
 
 ```js
-var axes = [
+const axes = [
   [2, 5, 9, 4, 8, 7],
   [3, 4, 6, 7, 1, 2]
 ];
 
-var labels = ['zero', 'one', 'two', 'three', 'four', 'five'];
+const labels = ['zero', 'one', 'two', 'three', 'four', 'five'];
 
-var tree = KDTree.fromAxes(axes, labels);
+const tree = KDTree.fromAxes(axes, labels);
 // Or, without labels:
-var tree = KDTree.fromAxes(axes);
+const tree = KDTree.fromAxes(axes);
 ```
 
 ## Members
@@ -72,7 +72,7 @@ var tree = KDTree.fromAxes(axes);
 Total number of items stored in the tree.
 
 ```js
-var data = [
+const data = [
   ['zero', [2, 3]],
   ['one', [5, 4]],
   ['two', [9, 6]],
@@ -81,7 +81,7 @@ var data = [
   ['five', [7, 2]]
 ];
 
-var tree = KDTree.from(data, 2);
+const tree = KDTree.from(data, 2);
 
 tree.size
 >>> 6
@@ -92,7 +92,7 @@ tree.size
 Number of dimensions of the space indexed by the tree.
 
 ```js
-var data = [
+const data = [
   ['zero', [2, 3]],
   ['one', [5, 4]],
   ['two', [9, 6]],
@@ -101,7 +101,7 @@ var data = [
   ['five', [7, 2]]
 ];
 
-var tree = KDTree.from(data, 2);
+const tree = KDTree.from(data, 2);
 
 tree.dimensions
 >>> 2
@@ -112,7 +112,7 @@ tree.dimensions
 Returns query point's nearest neighbor in the tree.
 
 ```js
-var data = [
+const data = [
   ['zero', [2, 3]],
   ['one', [5, 4]],
   ['two', [9, 6]],
@@ -121,7 +121,7 @@ var data = [
   ['five', [7, 2]]
 ];
 
-var tree = KDTree.from(data, 2);
+const tree = KDTree.from(data, 2);
 
 tree.nearestNeighbor([2, 4]);
 >>> 'zero'
@@ -132,7 +132,7 @@ tree.nearestNeighbor([2, 4]);
 Returns query point's `k` nearest neighbors in the tree, sorted from closest to farthest.
 
 ```js
-var data = [
+const data = [
   ['zero', [2, 3]],
   ['one', [5, 4]],
   ['two', [9, 6]],
@@ -141,7 +141,7 @@ var data = [
   ['five', [7, 2]]
 ];
 
-var tree = KDTree.from(data, 2);
+const tree = KDTree.from(data, 2);
 
 tree.kNearestNeighbors(2, [2, 4]);
 >>> ['zero', 'one']

--- a/linked-list.md
+++ b/linked-list.md
@@ -155,7 +155,7 @@ const list = new LinkedList();
 list.push(1);
 list.push(2);
 
-list.forEach(function(item, index, list) {
+list.forEach((item, index, list)=> {
   console.log(index, item);
 });
 ```

--- a/linked-list.md
+++ b/linked-list.md
@@ -12,7 +12,7 @@ However, and this is where this structure shine, a linked list is able to modify
 For more information about the Linked List, you can head [here](https://en.wikipedia.org/wiki/Linked_list#Singly_linked_list).
 
 ```js
-var LinkedList = require('mnemonist/linked-list');
+const LinkedList = require('mnemonist/linked-list');
 ```
 
 ## Constructor
@@ -24,7 +24,7 @@ The `LinkedList` takes no argument.
 Alternatively, one can build a `LinkedList` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var list = LinkedList.from([1, 2, 3]);
+const list = LinkedList.from([1, 2, 3]);
 ```
 
 ## Members
@@ -58,7 +58,7 @@ var list = LinkedList.from([1, 2, 3]);
 Number of items in the list.
 
 ```js
-var list = new LinkedList();
+const list = new LinkedList();
 list.size
 >>> 0
 ```
@@ -70,7 +70,7 @@ Adds an item at the end of the list.
 `O(1)`
 
 ```js
-var list = new LinkedList();
+const list = new LinkedList();
 
 list.push(1);
 ```
@@ -82,7 +82,7 @@ Adds an item at the beginning of the list.
 `O(1)`
 
 ```js
-var list = new LinkedList();
+const list = new LinkedList();
 
 list.unshift(1);
 ```
@@ -94,7 +94,7 @@ Remove & retrieves the first item of the list.
 `O(1)`
 
 ```js
-var list = new LinkedList();
+const list = new LinkedList();
 
 list.unshift(1);
 list.shift();
@@ -108,7 +108,7 @@ Completely clears the list of its items.
 `O(1)`
 
 ```js
-var list = new LinkedList();
+const list = new LinkedList();
 
 list.unshift(1);
 list.clear();
@@ -123,7 +123,7 @@ Retrieves the first item of the list.
 `O(1)`
 
 ```js
-var list = new LinkedList();
+const list = new LinkedList();
 
 list.unshift(1);
 list.first();
@@ -137,7 +137,7 @@ Retrieves the last item of the list.
 `O(1)`
 
 ```js
-var list = new LinkedList();
+const list = new LinkedList();
 
 list.push(1);
 list.push(2);
@@ -150,7 +150,7 @@ list.last();
 Iterates over the list by applying the callback on every item.
 
 ```js
-var list = new LinkedList();
+const list = new LinkedList();
 
 list.push(1);
 list.push(2);
@@ -165,7 +165,7 @@ list.forEach(function(item, index, list) {
 Converts the list into a JavaScript array.
 
 ```js
-var list = new LinkedList();
+const list = new LinkedList();
 
 list.push(1);
 list.push(2);
@@ -179,9 +179,9 @@ list.toArray();
 Returns an iterator over the list's values.
 
 ```js
-var list = LinkedList.from([1, 2, 3]);
+const list = LinkedList.from([1, 2, 3]);
 
-var iterator = list.values();
+const iterator = list.values();
 
 iteraror.next().value
 >>> 1
@@ -192,9 +192,9 @@ iteraror.next().value
 Returns an iterator over the list's entries.
 
 ```js
-var list = LinkedList.from([1, 2, 3]);
+const list = LinkedList.from([1, 2, 3]);
 
-var iterator = list.entries();
+const iterator = list.entries();
 
 iterator.next().value
 >>> [0, 1]
@@ -205,9 +205,9 @@ iterator.next().value
 Alternatively, you can iterate over a list's values using ES2015 `for...of` protocol:
 
 ```js
-var list = LinkedList.from([1, 2, 3]);
+const list = LinkedList.from([1, 2, 3]);
 
-for (var item of list) {
+for (const item of list) {
   console.log(item);
 }
 ```

--- a/lru-cache.md
+++ b/lru-cache.md
@@ -246,7 +246,7 @@ const cache = new LRUCache(10);
 cache.set('one', 1);
 cache.set('two', 2);
 
-cache.forEach(function(value, key, cache) {
+cache.forEach((value, key, cache) => {
   console.log(key, value);
 });
 ```

--- a/lru-cache.md
+++ b/lru-cache.md
@@ -14,9 +14,9 @@ For more information, you can check [this](https://en.wikipedia.org/wiki/Cache_r
 This implementation has been designed to work with a javascript raw object. You can alternatively find an implementation relying on ES6's `Map` object [here]({{ site.baseurl }}/lru-map). Depending on the precise use case (string keys, integer keys etc.), one or the other might be faster depending on js engine magic.
 
 ```js
-var LRUCache = require('mnemonist/lru-cache');
+const LRUCache = require('mnemonist/lru-cache');
 // If you need deletions
-var LRUCacheWithDelete = require('mnemonist/lru-cache-with-delete');
+const LRUCacheWithDelete = require('mnemonist/lru-cache-with-delete');
 ```
 
 ## Constructor
@@ -24,14 +24,14 @@ var LRUCacheWithDelete = require('mnemonist/lru-cache-with-delete');
 The `LRUCache` takes a single argument: the desired capacity.
 
 ```js
-var cache = new LRUCache(1000);
+const cache = new LRUCache(1000);
 ```
 
 Optionally, you can type the used keys & values in order to be more memory-efficient:
 
 ```js
 // First argument will be instantiated for keys, second one for values
-var cache = new LRUCache(Uint32Array, Float32Array, 1000);
+const cache = new LRUCache(Uint32Array, Float32Array, 1000);
 ```
 
 ### Static #.from
@@ -40,13 +40,15 @@ Alternatively, one can build a `LRUCache` from an arbitrary JavaScript iterable 
 
 ```js
 // Attempting the guess the given iterable's length/size
-var cache = LRUCache.from({one: 1, two: 2});
-
+const cache = LRUCache.from({one: 1, two: 2});
+```
+```js
 // Providing the desired capacity
-var cache = LRUCache.from({one: 1, two: 2}, 10);
-
+const cache = LRUCache.from({one: 1, two: 2}, 10);
+```
+```js
 // Typing the cache
-var cache = LRUCache.from({one: 1, two: 2}, Array, Uint8Array, 10);
+const cache = LRUCache.from({one: 1, two: 2}, Array, Uint8Array, 10);
 ```
 
 ## Members
@@ -83,7 +85,7 @@ var cache = LRUCache.from({one: 1, two: 2}, Array, Uint8Array, 10);
 Maximum number of items the cache is able to store.
 
 ```js
-var cache = new LRUCache(10);
+const cache = new LRUCache(10);
 cache.capacity
 >>> 10
 ```
@@ -93,7 +95,7 @@ cache.capacity
 Number of items actually in the cache.
 
 ```js
-var cache = new LRUCache(10);
+const cache = new LRUCache(10);
 cache.size
 >>> 0
 cache.set('one', 1);
@@ -108,7 +110,7 @@ Sets a value for the given key in the cache. If the cache is already full, the l
 `O(1)`
 
 ```js
-var cache = new LRUCache(10);
+const cache = new LRUCache(10);
 cache.set('one', 1);
 cache.has('one');
 >>> true
@@ -121,7 +123,7 @@ Sets a value for the given key in the cache. If the cache is already full, the l
 `O(1)`
 
 ```js
-var cache = new LRUCache(1);
+const cache = new LRUCache(1);
 cache.setpop('one', 1);
 >>> null
 cache.setpop('one', 10);
@@ -139,7 +141,7 @@ Beware, for performance reasons this method is only available on `LRUCacheWithDe
 `O(1)`
 
 ```js
-var cache = new LRUCacheWithDelete(1);
+const cache = new LRUCacheWithDelete(1);
 cache.set('one', 1)
 
 cache.delete('one');
@@ -158,7 +160,7 @@ Beware, for performance reasons this method is only available on `LRUCacheWithDe
 `O(1)`
 
 ```js
-var cache = new LRUCacheWithDelete(1);
+const cache = new LRUCacheWithDelete(1);
 cache.set('one', 1)
 
 cache.remove('one');
@@ -178,7 +180,7 @@ Completely clears the cache.
 `O(1)`
 
 ```js
-var cache = new LRUCache(10);
+const cache = new LRUCache(10);
 cache.set('one', 1);
 cache.clear();
 
@@ -197,7 +199,7 @@ If the key is found, the key is moved to the front of the underlying list to be 
 `O(1)`
 
 ```js
-var cache = new LRUCache(10);
+const cache = new LRUCache(10);
 cache.set('one', 1);
 cache.get('one');
 >>> 1
@@ -212,7 +214,7 @@ Unlike [`#.get`](#get), it does not modify the underlying list.
 `O(1)`
 
 ```js
-var cache = new LRUCache(10);
+const cache = new LRUCache(10);
 cache.set('one', 1);
 cache.peek('one');
 >>> 1
@@ -225,7 +227,7 @@ Retrieves whether the given key exists in the cache.
 `O(1)`
 
 ```js
-var cache = new LRUCache(10);
+const cache = new LRUCache(10);
 cache.set('one', 1);
 cache.has('one');
 >>> true
@@ -239,7 +241,7 @@ cache.has('two');
 Iterates over the cache from the most to the least recently used key-value pair.
 
 ```js
-var cache = new LRUCache(10);
+const cache = new LRUCache(10);
 
 cache.set('one', 1);
 cache.set('two', 2);
@@ -254,12 +256,12 @@ cache.forEach(function(value, key, cache) {
 Returns an iterator over the cache's keys from the most to the least recently used key.
 
 ```js
-var cache = new LRUCache(10);
+const cache = new LRUCache(10);
 
 cache.set('one', 1);
 cache.set('two', 2);
 
-var iterator = cache.keys();
+const iterator = cache.keys();
 
 iterator.next().value
 >>> 'two'
@@ -270,12 +272,12 @@ iterator.next().value
 Returns an iterator over the cache's values from the most to the least recently used value.
 
 ```js
-var cache = new LRUCache(10);
+const cache = new LRUCache(10);
 
 cache.set('one', 1);
 cache.set('two', 2);
 
-var iterator = cache.values();
+const iterator = cache.values();
 
 iterator.next().value
 >>> 2
@@ -286,12 +288,12 @@ iterator.next().value
 Returns an iterator over the cache's entries from the most to the least recently used entry.
 
 ```js
-var cache = new LRUCache(10);
+const cache = new LRUCache(10);
 
 cache.set('one', 1);
 cache.set('two', 2);
 
-var iterator = cache.entries();
+const iterator = cache.entries();
 
 iterator.next().value
 >>> ['two', 2]
@@ -302,12 +304,12 @@ iterator.next().value
 Alternatively, you can iterate over a cache's entries using ES2015 `for...of` protocol:
 
 ```js
-var cache = new LRUCache(10);
+const cache = new LRUCache(10);
 
 cache.set('one', 1);
 cache.set('two', 2);
 
-for (var [key, value] of cache) {
+for (const [key, value] of cache) {
   console.log(key, value);
 }
 ```

--- a/lru-map.md
+++ b/lru-map.md
@@ -247,7 +247,7 @@ const cache = new LRUMap(10);
 cache.set('one', 1);
 cache.set('two', 2);
 
-cache.forEach(function(value, key, cache) {
+cache.forEach((value, key, cache) => {
   console.log(key, value);
 });
 ```

--- a/lru-map.md
+++ b/lru-map.md
@@ -15,9 +15,9 @@ This implementation has been designed to work with an ES6 `Map` object. You can 
 
 
 ```js
-var LRUMap = require('mnemonist/lru-map');
+const LRUMap = require('mnemonist/lru-map');
 // If you need deletions
-var LRUMapWithDelete = require('mnemonist/lru-map-with-delete');
+const LRUMapWithDelete = require('mnemonist/lru-map-with-delete');
 ```
 
 ## Constructor
@@ -25,14 +25,14 @@ var LRUMapWithDelete = require('mnemonist/lru-map-with-delete');
 The `LRUMap` takes a single argument: the desired capacity.
 
 ```js
-var cache = new LRUMap(1000);
+const cache = new LRUMap(1000);
 ```
 
 Optionally, you can type the used keys & values in order to be more memory-efficient:
 
 ```js
 // First argument will be instantiated for keys, second one for values
-var cache = new LRUMap(Uint32Array, Float32Array, 1000);
+const cache = new LRUMap(Uint32Array, Float32Array, 1000);
 ```
 
 ### Static #.from
@@ -41,13 +41,15 @@ Alternatively, one can build a `LRUMap` from an arbitrary JavaScript iterable li
 
 ```js
 // Attempting the guess the given iterable's length/size
-var cache = LRUMap.from({one: 1, two: 2});
-
+const cache = LRUMap.from({one: 1, two: 2});
+```
+```js
 // Providing the desired capacity
-var cache = LRUMap.from({one: 1, two: 2}, 10);
-
+const cache = LRUMap.from({one: 1, two: 2}, 10);
+```
+```js
 // Typing the cache
-var cache = LRUMap.from({one: 1, two: 2}, Array, Uint8Array, 10);
+const cache = LRUMap.from({one: 1, two: 2}, Array, Uint8Array, 10);
 ```
 
 ## Members
@@ -84,7 +86,7 @@ var cache = LRUMap.from({one: 1, two: 2}, Array, Uint8Array, 10);
 Maximum number of items the cache is able to store.
 
 ```js
-var cache = new LRUMap(10);
+const cache = new LRUMap(10);
 cache.capacity
 >>> 10
 ```
@@ -94,7 +96,7 @@ cache.capacity
 Number of items actually in the cache.
 
 ```js
-var cache = new LRUMap(10);
+const cache = new LRUMap(10);
 cache.size
 >>> 0
 cache.set('one', 1);
@@ -109,7 +111,7 @@ Sets a value for the given key in the cache. If the cache is already full, the l
 `O(1)`
 
 ```js
-var cache = new LRUMap(10);
+const cache = new LRUMap(10);
 cache.set('one', 1);
 cache.has('one');
 >>> true
@@ -122,7 +124,7 @@ Sets a value for the given key in the cache. If the cache is already full, the l
 `O(1)`
 
 ```js
-var cache = new LRUMap(1);
+const cache = new LRUMap(1);
 cache.setpop('one', 1);
 >>> null
 cache.setpop('one', 10);
@@ -140,7 +142,7 @@ Beware, for performance reasons this method is only available on `LRUMapWithDele
 `O(1)`
 
 ```js
-var cache = new LRUMapWithDelete(1);
+const cache = new LRUMapWithDelete(1);
 cache.set('one', 1)
 
 cache.delete('one');
@@ -159,7 +161,7 @@ Beware, for performance reasons this method is only available on `LRUMapWithDele
 `O(1)`
 
 ```js
-var cache = new LRUMapWithDelete(1);
+const cache = new LRUMapWithDelete(1);
 cache.set('one', 1)
 
 cache.remove('one');
@@ -179,7 +181,7 @@ Completely clears the cache.
 `O(1)`
 
 ```js
-var cache = new LRUMap(10);
+const cache = new LRUMap(10);
 cache.set('one', 1);
 cache.clear();
 
@@ -198,7 +200,7 @@ If the key is found, the key is moved to the front of the underlying list to be 
 `O(1)`
 
 ```js
-var cache = new LRUMap(10);
+const cache = new LRUMap(10);
 cache.set('one', 1);
 cache.get('one');
 >>> 1
@@ -213,7 +215,7 @@ Unlike [`#.get`](#get), it does not modify the underlying list.
 `O(1)`
 
 ```js
-var cache = new LRUMap(10);
+const cache = new LRUMap(10);
 cache.set('one', 1);
 cache.peek('one');
 >>> 1
@@ -226,7 +228,7 @@ Retrieves whether the given key exists in the cache.
 `O(1)`
 
 ```js
-var cache = new LRUMap(10);
+const cache = new LRUMap(10);
 cache.set('one', 1);
 cache.has('one');
 >>> true
@@ -240,7 +242,7 @@ cache.has('two');
 Iterates over the cache from the most to the least recently used key-value pair.
 
 ```js
-var cache = new LRUMap(10);
+const cache = new LRUMap(10);
 
 cache.set('one', 1);
 cache.set('two', 2);
@@ -255,12 +257,12 @@ cache.forEach(function(value, key, cache) {
 Returns an iterator over the cache's keys from the most to the least recently used key.
 
 ```js
-var cache = new LRUMap(10);
+const cache = new LRUMap(10);
 
 cache.set('one', 1);
 cache.set('two', 2);
 
-var iterator = cache.keys();
+const iterator = cache.keys();
 
 iterator.next().value
 >>> 'two'
@@ -271,12 +273,12 @@ iterator.next().value
 Returns an iterator over the cache's values from the most to the least recently used value.
 
 ```js
-var cache = new LRUMap(10);
+const cache = new LRUMap(10);
 
 cache.set('one', 1);
 cache.set('two', 2);
 
-var iterator = cache.values();
+const iterator = cache.values();
 
 iterator.next().value
 >>> 2
@@ -287,12 +289,12 @@ iterator.next().value
 Returns an iterator over the cache's entries from the most to the least recently used entry.
 
 ```js
-var cache = new LRUMap(10);
+const cache = new LRUMap(10);
 
 cache.set('one', 1);
 cache.set('two', 2);
 
-var iterator = cache.entries();
+const iterator = cache.entries();
 
 iterator.next().value
 >>> ['two', 2]
@@ -303,12 +305,12 @@ iterator.next().value
 Alternatively, you can iterate over a cache's entries using ES2015 `for...of` protocol:
 
 ```js
-var cache = new LRUMap(10);
+const cache = new LRUMap(10);
 
 cache.set('one', 1);
 cache.set('two', 2);
 
-for (var [key, value] of cache) {
+for (const [key, value] of cache) {
   console.log(key, value);
 }
 ```

--- a/multi-map.md
+++ b/multi-map.md
@@ -223,7 +223,7 @@ const map = new MultiMap();
 map.set('john', {name: 'John', surname: 'Doe'});
 map.set('john', {name: 'John', surname: 'Watson'});
 
-map.forEach(function(value, key) {
+map.forEach((value, key) => {
   console.log(key, value);
 });
 >>> 'john', {name: 'John', surname: 'Doe'}
@@ -241,7 +241,7 @@ map.set(1, 1);
 map.set(1, 2);
 map.set(2, 1);
 
-map.forEachAssociation(function(container, key) {
+map.forEachAssociation((container, key) => {
   console.log(key, container);
 });
 >>> 1, [1, 2]

--- a/multi-map.md
+++ b/multi-map.md
@@ -8,7 +8,7 @@ A `MultiMap` is like a `Map` except it can store multiple values with the same k
 For more information about the MultiMap, you can head [here](https://en.wikipedia.org/wiki/Multimap).
 
 ```js
-var MultiMap = require('mnemonist/multi-map');
+const MultiMap = require('mnemonist/multi-map');
 ```
 
 ## Constructor
@@ -16,10 +16,11 @@ var MultiMap = require('mnemonist/multi-map');
 The `MultiMap` takes an optional argument being the container to use. By default, the container is an array.
 
 ```js
-var map = new MultiMap();
-
+const map = new MultiMap();
+```
+```js
 // Using a set as container
-var map = new MultiMap(Set);
+const map = new MultiMap(Set);
 ```
 
 ### Static #.from
@@ -27,7 +28,7 @@ var map = new MultiMap(Set);
 Alternatively, one can build a `MultiMap` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var map = MultiMap.from([1, 2, 3], container);
+const map = MultiMap.from([1, 2, 3], container);
 ```
 
 ## Members
@@ -67,7 +68,7 @@ var map = MultiMap.from([1, 2, 3], container);
 Number of containers stored by the map.
 
 ```js
-var map = new MultiMap();
+const map = new MultiMap();
 
 map.set('hello', 'world');
 
@@ -80,7 +81,7 @@ map.dimension
 Total number of items stored by the map.
 
 ```js
-var map = new MultiMap();
+const map = new MultiMap();
 
 map.set('J', 'John');
 map.set('J', 'Jack');
@@ -99,7 +100,7 @@ Adds an item to the multimap using the provided key.
 `O(1)`
 
 ```js
-var map = new MultiMap();
+const map = new MultiMap();
 
 map.set(key, value);
 ```
@@ -111,7 +112,7 @@ Removes every items stored using the provided key.
 `O(1)`
 
 ```js
-var map = new MultiMap();
+const map = new MultiMap();
 
 map.set('J', 'John');
 map.set('J', 'Jack');
@@ -135,7 +136,7 @@ Note that it will remove only one such value from array-like containers.
 `O(n)` for Array containers.
 
 ```js
-var map = new MultiMap();
+const map = new MultiMap();
 
 map.set('one', 'Hello');
 
@@ -150,7 +151,7 @@ map.get('one');
 Completely clears the multimap of every item.
 
 ```js
-var map = new MultiMap();
+const map = new MultiMap();
 
 map.set('J', 'John');
 map.set('J', 'Jack');
@@ -172,7 +173,7 @@ Returns whether the map holds a container at the given key.
 `O(1)`
 
 ```js
-var map = new MultiMap();
+const map = new MultiMap();
 
 map.set('john', {name: 'John'});
 
@@ -187,7 +188,7 @@ Returns the number of times the given key is set in the map. Or more simply said
 `O(1)`
 
 ```js
-var map = new MultiMap();
+const map = new MultiMap();
 
 map.multiplicity('hello');
 >>> 0
@@ -204,7 +205,7 @@ Returns the container at the given key or `undefined`.
 `O(1)`
 
 ```js
-var map = new MultiMap();
+const map = new MultiMap();
 
 map.set('john', {name: 'John'});
 
@@ -217,7 +218,7 @@ map.get('john');
 Iterates over each of the entries of the multimap.
 
 ```js
-var map = new MultiMap();
+const map = new MultiMap();
 
 map.set('john', {name: 'John', surname: 'Doe'});
 map.set('john', {name: 'John', surname: 'Watson'});
@@ -234,7 +235,7 @@ map.forEach(function(value, key) {
 Iterates over each of the associations (key, container) of the multimap.
 
 ```js
-var map = new Multimap();
+const map = new Multimap();
 
 map.set(1, 1);
 map.set(1, 2);
@@ -252,12 +253,12 @@ map.forEachAssociation(function(container, key) {
 Returns an iterator over the keys of the multimap.
 
 ```js
-var map = new MultiMap();
+const map = new MultiMap();
 
 map.set('john', {name: 'John', surname: 'Doe'});
 map.set('john', {name: 'John', surname: 'Watson'});
 
-var iterator = map.keys();
+const iterator = map.keys();
 
 iterator.next().value
 >>> 'john'
@@ -268,12 +269,12 @@ iterator.next().value
 Returns an iterator over the values of the multimap.
 
 ```js
-var map = new MultiMap();
+const map = new MultiMap();
 
 map.set('john', {name: 'John', surname: 'Doe'});
 map.set('john', {name: 'John', surname: 'Watson'});
 
-var iterator = map.values();
+const iterator = map.values();
 
 iterator.next().value
 >>> {name: 'John', surname: 'Doe'}
@@ -284,12 +285,12 @@ iterator.next().value
 Returns an iterator over the entries of the multimap.
 
 ```js
-var map = new MultiMap();
+const map = new MultiMap();
 
 map.set('john', {name: 'John', surname: 'Doe'});
 map.set('john', {name: 'John', surname: 'Watson'});
 
-var iterator = map.entries();
+const iterator = map.entries();
 
 iterator.next().value
 >>> ['john', {name: 'John', surname: 'Doe'}]
@@ -300,12 +301,12 @@ iterator.next().value
 Returns an iterator over the containers of the multimap.
 
 ```js
-var map = new MultiMap();
+const map = new MultiMap();
 
 map.set('john', {name: 'John', surname: 'Doe'});
 map.set('john', {name: 'John', surname: 'Watson'});
 
-var iterator = map.containers();
+const iterator = map.containers();
 
 iterator.next().value
 >>> [
@@ -319,12 +320,12 @@ iterator.next().value
 Returns an iterator over the associations (key, container) of the multimap.
 
 ```js
-var map = new MultiMap();
+const map = new MultiMap();
 
 map.set('john', {name: 'John', surname: 'Doe'});
 map.set('john', {name: 'John', surname: 'Watson'});
 
-var iterator = map.associations();
+const iterator = map.associations();
 
 iterator.next().value
 >>> [
@@ -341,12 +342,12 @@ iterator.next().value
 Alternatively, you can iterate over a list's entries using ES2015 `for...of` protocol:
 
 ```js
-var map = new MultiMap();
+const map = new MultiMap();
 
 map.set('john', {name: 'John', surname: 'Doe'});
 map.set('john', {name: 'John', surname: 'Watson'});
 
-for (var entry of map) {
+for (const entry of map) {
   console.log(entry);
 }
 ```

--- a/multi-set.md
+++ b/multi-set.md
@@ -8,7 +8,7 @@ A `MultiSet` is like a `Set` excepts it is able to store items more than once an
 For more information about the MultiSet, you can head [here](https://en.wikipedia.org/wiki/Multiset).
 
 ```js
-var MultiSet = require('mnemonist/multi-set');
+const MultiSet = require('mnemonist/multi-set');
 ```
 
 ## Constructor
@@ -20,7 +20,7 @@ The `MultiSet` takes no argument.
 Alternatively, one can build a `MultiSet` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var set = MultiSet.from([1, 2, 3]);
+const set = MultiSet.from([1, 2, 3]);
 ```
 
 ## Members
@@ -69,7 +69,7 @@ Static methods dealing with multisets.
 Number of distinct items in the set.
 
 ```js
-var set = new MultiSet();
+const set = new MultiSet();
 
 set.add('hello');
 set.add('hello');
@@ -83,7 +83,7 @@ set.dimension
 Total number of items in the set.
 
 ```js
-var set = new MultiSet();
+const set = new MultiSet();
 
 set.add('hello');
 set.add('hello');
@@ -103,7 +103,7 @@ Adding an item a negative number of times will remove items.
 `O(1)`
 
 ```js
-var set = new MultiSet();
+const set = new MultiSet();
 
 set.add('hello');
 
@@ -120,7 +120,7 @@ Setting the multiplicity of an item to be 0 or a negative number will remove sai
 `O(1)`
 
 ```js
-var set = new MultiSet();
+const set = new MultiSet();
 
 set.set('hello', 4);
 set.multiplicity('hello');
@@ -138,7 +138,7 @@ Removing an item a negative number of times will add items.
 `O(1)`
 
 ```js
-var set = new MultiSet();
+const set = new MultiSet();
 
 set.add('hello', 3);
 
@@ -158,7 +158,7 @@ Removes all the occurrences of the given item from the set.
 `O(1)`
 
 ```js
-var set = new MultiSet();
+const set = new MultiSet();
 
 set.add('hello');
 set.add('hello');
@@ -175,7 +175,7 @@ Edit an item to become another one. If the item does not exist in the set, this 
 `O(1)`
 
 ```js
-var set = new MultiSet();
+const set = new MultiSet();
 
 set.add('a');
 set.add('b');
@@ -196,7 +196,7 @@ set.multiplicity('b');
 Completly clears the set of all its items.
 
 ```js
-var set = new MultiSet();
+const set = new MultiSet();
 
 set.add('hello');
 set.clear();
@@ -216,7 +216,7 @@ Returns the frequency of the given item in the set.
 `O(1)`
 
 ```js
-var set = new MultiSet();
+const set = new MultiSet();
 
 set.add('apple', 5);
 set.add('pear', 2);
@@ -233,7 +233,7 @@ Returns whether the given item is found in the set.
 `O(1)`
 
 ```js
-var set = new MultiSet();
+const set = new MultiSet();
 
 set.add('hello');
 set.has('hello');
@@ -254,7 +254,7 @@ Returns the number of times the given item is found in the set.
 `O(1)`
 
 ```js
-var set = new MultiSet();
+const set = new MultiSet();
 
 set.add('hello');
 set.multiplicity('hello');
@@ -270,7 +270,7 @@ Retrieves the top k items with their assorted count in sorted order.
 `O(k)` memory
 
 ```js
-var set = MultiSet.from('So-many-letters-in-this-boring-string.');
+const set = MultiSet.from('So-many-letters-in-this-boring-string.');
 set.top(3);
 >>> [['-', 6], ['t', 4], ['n', 4]]
 ```
@@ -280,7 +280,7 @@ set.top(3);
 Iterates over each of the items stored by the set.
 
 ```js
-var set = new MultiSet();
+const set = new MultiSet();
 
 set.add('hello');
 set.add('hello');
@@ -297,7 +297,7 @@ set.forEach(function(value) {
 Iterates over each of the multiplicities stored by the set.
 
 ```js
-var set = new MultiSet();
+const set = new MultiSet();
 
 set.add('hello');
 set.add('hello');
@@ -315,12 +315,12 @@ set.forEachMultiplicity(function(count, key) {
 Returns an iterator over the set's keys, i.e. the set's unique values.
 
 ```js
-var set = new MultiSet();
+const set = new MultiSet();
 
 set.add('hello', 4);
 set.add('world', 5);
 
-var iterator = set.keys();
+const iterator = set.keys();
 
 iterator.next().value
 >>> 'hello'
@@ -333,12 +333,12 @@ iterator.next().value
 Returns an iterator over the set's repeated values.
 
 ```js
-var set = new MultiSet();
+const set = new MultiSet();
 
 set.add('hello', 2);
 set.add('world');
 
-var iterator = set.values();
+const iterator = set.values();
 
 iterator.next().value
 >>> 'hello'
@@ -351,12 +351,12 @@ iterator.next().value
 Returns an iterator over the set's multiplicities.
 
 ```js
-var set = new MultiSet();
+const set = new MultiSet();
 
 set.add('hello');
 set.add('hello');
 
-var iterator = set.multiplicities();
+const iterator = set.multiplicities();
 
 iterator.next().value
 >>> ['hello', 2]
@@ -367,12 +367,12 @@ iterator.next().value
 Alternatively, you can iterate over a set's values using ES2015 `for...of` protocol:
 
 ```js
-var set = new MultiSet();
+const set = new MultiSet();
 
 set.add('hello');
 set.add('hello');
 
-for (var value of set) {
+for (const value of set) {
   console.log(value);
 }
 ```
@@ -386,8 +386,8 @@ for (var value of set) {
 Static method returning whether the first multiset is a subset of the second.
 
 ```js
-var letters = MultiSet.from('aaabbc');
-var lessLetters = MultiSet.from('aab');
+const letters = MultiSet.from('aaabbc');
+const lessLetters = MultiSet.from('aab');
 
 MultiSet.isSubset(lessLetters, letters);
 >>> true
@@ -398,8 +398,8 @@ MultiSet.isSubset(lessLetters, letters);
 Static method returning whether the first multiset is a superset of the second.
 
 ```js
-var letters = MultiSet.from('aaabbc');
-var lessLetters = MultiSet.from('aab');
+const letters = MultiSet.from('aaabbc');
+const lessLetters = MultiSet.from('aab');
 
 MultiSet.isSuperset(letters, lessLetters);
 >>> true

--- a/multi-set.md
+++ b/multi-set.md
@@ -285,7 +285,7 @@ const set = new MultiSet();
 set.add('hello');
 set.add('hello');
 
-set.forEach(function(value) {
+set.forEach((value) => {
   console.log(value);
 });
 >>> 'hello'
@@ -303,7 +303,7 @@ set.add('hello');
 set.add('hello');
 set.add('world');
 
-set.forEachMultiplicity(function(count, key) {
+set.forEachMultiplicity((count, key) => {
   console.log(key, count);
 });
 >>> 'hello', 2

--- a/passjoin-index.md
+++ b/passjoin-index.md
@@ -165,7 +165,7 @@ const index = new PassjoinIndex(levenshtein, 1);
 index.add('roman');
 index.add('flailed');
 
-index.forEach(function(string) {
+index.forEach((string) => {
   console.log(string);
 });
 ```

--- a/passjoin-index.md
+++ b/passjoin-index.md
@@ -18,7 +18,7 @@ This is very good because its performance mostly depends on `k` being low, which
 Note that the real complexity is very hard to assess and depends on your dataset's substring clustering etc. so your mileage may vary.
 
 ```js
-var PassjoinIndex = require('mnemonist/passjoin-index');
+const PassjoinIndex = require('mnemonist/passjoin-index');
 ```
 
 **References**
@@ -36,9 +36,7 @@ When the user inputs a string, we are going to search for every term we know bei
 The naive method would be to "brute-force" the list of terms likewise:
 
 ```js
-var suggestions = terms.filter(term => {
-  return levenshtein(term, query) <= 2;
-});
+const suggestions = terms.filter((term) => levenshtein(term, query) <= 2);
 ```
 
 But, even if this works with few terms, it will soon become hard to compute if the list of terms grows too much.
@@ -46,10 +44,10 @@ But, even if this works with few terms, it will soon become hard to compute if t
 A `PassjoinIndex` solves this problem by indexing the list of terms such as it becomes efficient to query them:
 
 ```js
-var tree = PassjoinIndex.from(terms, levenshtein, 2);
+const tree = PassjoinIndex.from(terms, levenshtein, 2);
 
 // We can now search the index easily:
-var suggestions = tree.search(query);
+const suggestions = tree.search(query);
 ```
 
 
@@ -77,7 +75,7 @@ If `k` is 1, we recommend the following specialized library:
 Alternatively, one can build a `PassjoinIndex` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var index = PassjoinIndex.from(['roman', 'roma'], levenshtein, 2);
+const index = PassjoinIndex.from(['roman', 'roma'], levenshtein, 2);
 ```
 
 ## Members
@@ -106,7 +104,7 @@ var index = PassjoinIndex.from(['roman', 'roma'], levenshtein, 2);
 Number of items in the index.
 
 ```js
-var index = new PassjoinIndex(levenshtein, 1);
+const index = new PassjoinIndex(levenshtein, 1);
 index.size
 >>> 0
 
@@ -122,7 +120,7 @@ Adds a string to the index.
 `O(kn)`
 
 ```js
-var index = new PassjoinIndex(levenshtein, 1);
+const index = new PassjoinIndex(levenshtein, 1);
 
 index.add('roman');
 ```
@@ -132,7 +130,7 @@ index.add('roman');
 Completely clears the index.
 
 ```js
-var index = new PassjoinIndex(levenshtein, 1);
+const index = new PassjoinIndex(levenshtein, 1);
 
 index.add('roman');
 index.clear();
@@ -148,7 +146,7 @@ Returns the set of every string matching the query in the index, i.e. every stri
 `~O(k^3)`
 
 ```js
-var index = new PassjoinIndex(levenshtein, 1);
+const index = new PassjoinIndex(levenshtein, 1);
 
 index.add('flailed');
 index.add('roman');
@@ -162,7 +160,7 @@ index.search('failed');
 Iterates over the indexed strings.
 
 ```js
-var index = new PassjoinIndex(levenshtein, 1);
+const index = new PassjoinIndex(levenshtein, 1);
 
 index.add('roman');
 index.add('flailed');
@@ -177,9 +175,9 @@ index.forEach(function(string) {
 Returns an iterator over the indexed values.
 
 ```js
-var index = PassjoinIndex.from(['roman', 'flailed']);
+const index = PassjoinIndex.from(['roman', 'flailed']);
 
-var iterator = index.values();
+const iterator = index.values();
 
 iterator.next().value
 >>> 'roman'
@@ -190,9 +188,9 @@ iterator.next().value
 Alternatively, you can iterate over indexed values using ES2015 `for...of` protocol:
 
 ```js
-var index = PassjoinIndex.from(['roman', 'flailed']);
+const index = PassjoinIndex.from(['roman', 'flailed']);
 
-for (var string of index) {
+for (const string of index) {
   console.log(string);
 }
 ```

--- a/queue.md
+++ b/queue.md
@@ -27,7 +27,7 @@ while (queue.size) {
   const node = queue.dequeue();
   console.log('Traversed node:', node);
 
-  node.children.forEach(function(child) {
+  node.children.forEach((child) => {
     queue.enqueue(child);
   });
 }
@@ -150,7 +150,7 @@ const queue = new Queue();
 queue.enqueue(1);
 queue.enqueue(2);
 
-queue.forEach(function(item, index, queue) {
+queue.forEach((item, index, queue) => {
   console.log(index, item);
 });
 ```

--- a/queue.md
+++ b/queue.md
@@ -12,7 +12,7 @@ For more information about the Queue, you can head [here](https://en.wikipedia.o
 If you know the maximum number of items your queue will need to store, you should check the [`CircularBuffer`]({{ site.baseurl }}/circular-buffer) structure for better performance. 
 
 ```js
-var Queue = require('mnemonist/queue');
+const Queue = require('mnemonist/queue');
 ```
 
 ## Use case
@@ -20,11 +20,11 @@ var Queue = require('mnemonist/queue');
 A queue is really useful to perform, for instance, the breadth-first traversal of a tree:
 
 ```js
-var queue = new Queue();
+const queue = new Queue();
 queue.enqueue(tree.root);
 
 while (queue.size) {
-  var node = queue.dequeue();
+  const node = queue.dequeue();
   console.log('Traversed node:', node);
 
   node.children.forEach(function(child) {
@@ -42,7 +42,7 @@ The `Queue` takes no argument.
 Alternatively, one can build a `Queue` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var list = Queue.from([1, 2, 3]);
+const list = Queue.from([1, 2, 3]);
 ```
 
 ### Static #.of
@@ -50,7 +50,7 @@ var list = Queue.from([1, 2, 3]);
 You can also build a `Queue` from an arbitrary set of arguments:
 
 ```js
-var queue = Queue.of(1, 2, 3);
+const queue = Queue.of(1, 2, 3);
 ```
 
 ## Members
@@ -82,7 +82,7 @@ var queue = Queue.of(1, 2, 3);
 Number of items in the queue.
 
 ```js
-var queue = new Queue();
+const queue = new Queue();
 queue.size
 >>> 0
 ```
@@ -94,7 +94,7 @@ Adds an item to the queue.
 `O(1)`
 
 ```js
-var queue = new Queue();
+const queue = new Queue();
 
 queue.enqueue(1);
 ```
@@ -106,7 +106,7 @@ Retrieve & remove the next item of the queue.
 `O(1) amortized`
 
 ```js
-var queue = new Queue();
+const queue = new Queue();
 
 queue.enqueue(1);
 queue.dequeue();
@@ -118,7 +118,7 @@ queue.dequeue();
 Completely clears the queue.
 
 ```js
-var queue = new Queue();
+const queue = new Queue();
 
 queue.enqueue(1);
 queue.clear();
@@ -133,7 +133,7 @@ Retrieves the next item of the queue.
 `O(1)`
 
 ```js
-var queue = new Queue();
+const queue = new Queue();
 
 queue.enqueue(1);
 queue.peek();
@@ -145,7 +145,7 @@ queue.peek();
 Iterates over the queue in FIFO order.
 
 ```js
-var queue = new Queue();
+const queue = new Queue();
 
 queue.enqueue(1);
 queue.enqueue(2);
@@ -160,7 +160,7 @@ queue.forEach(function(item, index, queue) {
 Converts the queue into a FIFO JavaScript array.
 
 ```js
-var queue = new Queue();
+const queue = new Queue();
 
 queue.enqueue(1);
 queue.enqueue(2);
@@ -174,9 +174,9 @@ queue.toArray();
 Returns an iterator over the queue's values.
 
 ```js
-var queue = Queue.from([1, 2, 3]);
+const queue = Queue.from([1, 2, 3]);
 
-var iterator = queue.values();
+const iterator = queue.values();
 
 iterator.next().value
 >>> 1
@@ -187,9 +187,9 @@ iterator.next().value
 Returns an iterator over the queue's entries.
 
 ```js
-var queue = Queue.from([1, 2, 3]);
+const queue = Queue.from([1, 2, 3]);
 
-var iterator = queue.entries();
+const iterator = queue.entries();
 
 iterator.next().value
 >>> [0, 1]
@@ -200,9 +200,9 @@ iterator.next().value
 Alternatively, you can iterate over a queue's values using ES2015 `for...of` protocol:
 
 ```js
-var queue = Queue.from([1, 2, 3]);
+const queue = Queue.from([1, 2, 3]);
 
-for (var item of queue) {
+for (const item of queue) {
   console.log(item);
 }
 ```

--- a/search-index.md
+++ b/search-index.md
@@ -50,10 +50,10 @@ index.get(queryTitle);
 Alternatively, one can build an `SearchIndex` from an arbitrary JavaScript iterable likewise:
 
 ```js
-const index = SearchIndex.from(list, tokenizer [, useSet=false]);
+const index = InvertedIndex.from(list, tokenizer);
 ```
 ```js
-const index = SearchIndex.from(list, tokenizers [, useSet=false]);
+const index = InvertedIndex.from(list, tokenizers);
 ```
 
 ## Members

--- a/search-index.md
+++ b/search-index.md
@@ -19,9 +19,7 @@ The `SearchIndex` either takes a single argument being a tokenizer function that
 
 ```js
 // Let's create an index using a single hash function:
-const index = new SearchIndex(function(value) {
-  return words(value);
-});
+const index = new SearchIndex((value) => words(value));
 
 // Then you'll probably use #.set to insert items
 index.set(movie.title, movie);
@@ -35,14 +33,11 @@ index.get(queryTitle);
 const index = new Index([
   
   // Tokenizer function for inserted items:
-  function(movie) {
-    return words(movie.title);
-  },
+  (movie) => words(movie.title),
 
   // Tokenizer function for queries
-  function(query) {
-    return words(query);
-  }
+  (query) => words(query),
+
 ]);
 
 // Then you'll probably use #.add to insert items

--- a/search-index.md
+++ b/search-index.md
@@ -8,7 +8,7 @@ The `SearchIndex` is the name this library gives to an [`InvertedIndex`]({{ site
 Furthermore, the `SearchIndex` is able to compute some metrics such as TF/IDF to help you score the results.
 
 ```js
-var SearchIndex = require('mnemonist/search-index');
+const SearchIndex = require('mnemonist/search-index');
 ```
 
 ## Constructor
@@ -19,7 +19,7 @@ The `SearchIndex` either takes a single argument being a tokenizer function that
 
 ```js
 // Let's create an index using a single hash function:
-var index = new SearchIndex(function(value) {
+const index = new SearchIndex(function(value) {
   return words(value);
 });
 
@@ -32,7 +32,7 @@ index.get(queryTitle);
 
 ```js
 // Let's create an index using two different hash functions:
-var index = new Index([
+const index = new Index([
   
   // Tokenizer function for inserted items:
   function(movie) {
@@ -55,8 +55,10 @@ index.get(queryTitle);
 Alternatively, one can build an `SearchIndex` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var index = SearchIndex.from(list, tokenizer [, useSet=false]);
-var index = SearchIndex.from(list, tokenizers [, useSet=false]);
+const index = SearchIndex.from(list, tokenizer [, useSet=false]);
+```
+```js
+const index = SearchIndex.from(list, tokenizers [, useSet=false]);
 ```
 
 ## Members
@@ -82,7 +84,7 @@ var index = SearchIndex.from(list, tokenizers [, useSet=false]);
 Number of documents stored in the index.
 
 ```js
-var index = new SearchIndex(words);
+const index = new SearchIndex(words);
 
 index.add('The cat eats the mouse.');
 
@@ -95,7 +97,7 @@ index.size
 Tokenize the given document using the relevant function and adds it to the index.
 
 ```js
-var index = new SearchIndex(words);
+const index = new SearchIndex(words);
 
 index.add('The cat eats the mouse.');
 ```
@@ -105,9 +107,9 @@ index.add('The cat eats the mouse.');
 Tokenize the given key using the relevant function and add the given document to the index.
 
 ```js
-var index = new SearchIndex(words);
+const index = new SearchIndex(words);
 
-var doc = {text: 'The cat eats the mouse.', id: 34}
+const doc = {text: 'The cat eats the mouse.', id: 34}
 
 index.set(doc.text, doc);
 ```
@@ -117,7 +119,7 @@ index.set(doc.text, doc);
 Completely clears the index of its documents.
 
 ```js
-var index = new SearchIndex(words);
+const index = new SearchIndex(words);
 
 index.add('The cat eats the mouse.');
 index.clear();
@@ -133,7 +135,7 @@ index.size
 Tokenize the query using the relevant function, then retrieves the intersection of documents containing the resulting tokens.
 
 ```js
-var index = new SearchIndex(words);
+const index = new SearchIndex(words);
 
 index.add('The cat eats the mouse.');
 index.add('The mouse eats cheese.');
@@ -152,7 +154,7 @@ index.get('cat mouse');
 Tokenize the query using the relevant function, then retrieves the union of documents containing the resulting tokens.
 
 ```js
-var index = new SearchIndex(words);
+const index = new SearchIndex(words);
 
 index.add('The cat eats the mouse.');
 index.add('The mouse eats cheese.');

--- a/set.md
+++ b/set.md
@@ -10,7 +10,7 @@ However, it direly lacks of some typical helpers such as functions computing the
 That's what the `mnemonist/set` module provides.
 
 ```js
-var helpers = require('mnemonist/set');
+const helpers = require('mnemonist/set');
 ```
 
 ## Functions
@@ -46,14 +46,14 @@ var helpers = require('mnemonist/set');
 Returns the intersection of the given sets.
 
 ```js
-var A = new Set([1, 2, 3]),
-    B = new Set([2, 3, 4]);
+const A = new Set([1, 2, 3]);
+const B = new Set([2, 3, 4]);
 
 helpers.intersection(A, B);
 >>> Set {2, 3}
 
 // You can intersect as many sets as you want:
-var C = new Set([1, 2]);
+const C = new Set([1, 2]);
 
 helpers.intersection(A, B, C);
 >>> Set {2}
@@ -64,14 +64,14 @@ helpers.intersection(A, B, C);
 Returns the union of the given sets.
 
 ```js
-var A = new Set([1, 2, 3]),
+const A = new Set([1, 2, 3]),
     B = new Set([2, 3, 4]);
 
 helpers.union(A, B);
 >>> Set {1, 2, 3, 4}
 
 // You can unite as many sets as you want:
-var C = new Set([1, 2]);
+const C = new Set([1, 2]);
 
 helpers.union(A, B, C);
 >>> Set {1, 2, 3, 4}
@@ -82,8 +82,8 @@ helpers.union(A, B, C);
 Returns the difference of the given sets.
 
 ```js
-var A = new Set([1, 2, 3]),
-    B = new Set([2, 3, 4]);
+const A = new Set([1, 2, 3]);
+const B = new Set([2, 3, 4]);
 
 helpers.difference(A, B);
 >>> Set {1}
@@ -94,8 +94,8 @@ helpers.difference(A, B);
 Returns the symmetric difference (disjunction) of the given sets.
 
 ```js
-var A = new Set([1, 2, 3]),
-    B = new Set([2, 3, 4]);
+const A = new Set([1, 2, 3]);
+const B = new Set([2, 3, 4]);
 
 helpers.symmetricDifference(A, B);
 >>> Set {1, 4}
@@ -106,9 +106,9 @@ helpers.symmetricDifference(A, B);
 Returns whether the first set is a subset of the second one.
 
 ```js
-var A = new Set([1, 2]),
-    B = new Set([1, 2, 3]),
-    C = new Set([1, 4]);
+const A = new Set([1, 2]);
+const B = new Set([1, 2, 3]);
+const C = new Set([1, 4]);
 
 helpers.isSubset(A, B);
 >>> true
@@ -122,9 +122,9 @@ helpers.isSubset(A, C);
 Returns whether the first set is a superset of the second one.
 
 ```js
-var A = new Set([1, 2]),
-    B = new Set([1, 2, 3]),
-    C = new Set([1, 4]);
+const A = new Set([1, 2]);
+const B = new Set([1, 2, 3]);
+const C = new Set([1, 4]);
 
 helpers.isSuperset(B, A);
 >>> true
@@ -138,7 +138,7 @@ helpers.isSuperset(A, C);
 Adds the items of the second set to the first one in-place.
 
 ```js
-var A = new Set([1, 2]);
+const A = new Set([1, 2]);
 
 helpers.add(A, new Set([2, 3]));
 
@@ -151,7 +151,7 @@ helpers.add(A, new Set([2, 3]));
 Subtracts the items of the second set from the first one in-place.
 
 ```js
-var A = new Set([1, 2, 3, 4]);
+const A = new Set([1, 2, 3, 4]);
 
 helpers.subtract(A, new Set([1, 2]));
 
@@ -164,8 +164,8 @@ helpers.subtract(A, new Set([1, 2]));
 Mutates the first set to become the intersection of both given sets.
 
 ```js
-var A = new Set([1, 2, 3]),
-    B = new Set([2, 3, 4]);
+const A = new Set([1, 2, 3]);
+const B = new Set([2, 3, 4]);
 
 helpers.intersect(A, B);
 
@@ -178,8 +178,8 @@ helpers.intersect(A, B);
 Mutates the first set to become the disjunction (symmetric difference) of both given sets.
 
 ```js
-var A = new Set([1, 2, 3]),
-    B = new Set([2, 3, 4]);
+const A = new Set([1, 2, 3]);
+const B = new Set([2, 3, 4]);
 
 helpers.disjunct(A, B);
 
@@ -192,8 +192,8 @@ helpers.disjunct(A, B);
 Returns the size of the intersection of both given sets.
 
 ```js
-var A = new Set([1, 2, 3]),
-    B = new Set([2, 3, 4]);
+const A = new Set([1, 2, 3]);
+const B = new Set([2, 3, 4]);
 
 helpers.intersectionSize(A, B);
 >>> 2
@@ -207,8 +207,8 @@ helpers.intersection(A, B).size;
 Returns the size of the union of both given sets.
 
 ```js
-var A = new Set([1, 2, 3]),
-    B = new Set([2, 3, 4]);
+const A = new Set([1, 2, 3]);
+const B = new Set([2, 3, 4]);
 
 helpers.unionSize(A, B);
 >>> 4
@@ -222,8 +222,8 @@ helpers.union(A, B).size;
 Returns the [Jaccard Index](https://en.wikipedia.org/wiki/Jaccard_index) or similarity (i.e. intersection divided by union) between both given sets.
 
 ```js
-var contact = new Set('contact'),
-    context = new Set('context');
+const contact = new Set('contact');
+const context = new Set('context');
 
 helpers.jaccard(contact, context);
 >>> 4 / 7
@@ -234,8 +234,8 @@ helpers.jaccard(contact, context);
 Returns the [overlap coefficient](https://en.wikipedia.org/wiki/Overlap_coefficient) (i.e. intersection divided by min size) between both given sets.
 
 ```js
-var contact = new Set('contact'),
-    context = new Set('context');
+const contact = new Set('contact');
+const context = new Set('context');
 
 helpers.overlap(contact, context);
 >>> 4 / 5

--- a/sparse-map.md
+++ b/sparse-map.md
@@ -164,7 +164,7 @@ const map = new SparseMap(4);
 
 map.set(1, 23);
 
-map.forEach(function(value, key) {
+map.forEach((value, key) => {
   console.log(key, value);
 });
 ```

--- a/sparse-map.md
+++ b/sparse-map.md
@@ -10,7 +10,7 @@ Contrary to the [`BitSet`]({{ site.baseurl }}/bit-set), the `SparseMap` is very 
 If you don't need to associate values to your numbers, take a look to [`SparseSet`]({{ site.baseurl }}/sparse-set) instead.
 
 ```js
-var SparseMap = require('mnemonist/sparse-map');
+const SparseMap = require('mnemonist/sparse-map');
 ```
 
 ## Constructor
@@ -18,10 +18,11 @@ var SparseMap = require('mnemonist/sparse-map');
 The `SparseMap` takes a maximum length to store as well as, optionally, a constructor for the array that will store the map's values. This can be useful when storing, say, small positive integers and you want to save memory.
 
 ```js
-var map = new SparseMap(length);
-
+const map = new SparseMap(length);
+```
+```js
 // If you know your values type:
-var map = new SparseMap(Uint8Array, length);
+const map = new SparseMap(Uint8Array, length);
 ```
 
 ## Members
@@ -55,7 +56,7 @@ var map = new SparseMap(Uint8Array, length);
 Length of the map, that is to say the maximum number one can expect to store in this set minus one.
 
 ```js
-var map = new SparseMap(4);
+const map = new SparseMap(4);
 
 map.length;
 >>> 4
@@ -66,7 +67,7 @@ map.length;
 Number of items currently in the map.
 
 ```js
-var map = new SparseMap(4);
+const map = new SparseMap(4);
 
 map.size;
 >>> 0
@@ -84,7 +85,7 @@ Associates a value to the given number in the map.
 `O(1)`
 
 ```js
-var map = new SparseMap(4);
+const map = new SparseMap(4);
 
 map.set(2, 34);
 map.get(2);
@@ -98,7 +99,7 @@ Deletes the given number from the map.
 `O(1)`
 
 ```js
-var map = new SparseMap(4);
+const map = new SparseMap(4);
 
 map.set(2, 34);
 map.delete(2);
@@ -111,7 +112,7 @@ map.has(2);
 Resets every number stored by the map.
 
 ```js
-var map = new SparseMap(4);
+const map = new SparseMap(4);
 
 map.set(1);
 map.set(3);
@@ -128,7 +129,7 @@ Returns whether the given number exists in the map.
 `O(1)`
 
 ```js
-var map = new SparseMap(4);
+const map = new SparseMap(4);
 
 map.has(3);
 >>> false
@@ -143,7 +144,7 @@ map.has(3);
 Returns the value currently associated to the given number in the map.
 
 ```js
-var map = new SparseMap(4);
+const map = new SparseMap(4);
 
 map.get(3);
 >>> undefined
@@ -159,7 +160,7 @@ map.get(3);
 Iterates over the map's entries.
 
 ```js
-var map = new SparseMap(4);
+const map = new SparseMap(4);
 
 map.set(1, 23);
 
@@ -173,11 +174,11 @@ map.forEach(function(value, key) {
 Returns an iterator over the map's keys.
 
 ```js
-var map = new SparseMap(4);
+const map = new SparseMap(4);
 
 map.set(2, 15);
 
-var iterator = map.keys();
+const iterator = map.keys();
 
 iteraror.next().value
 >>> 2
@@ -188,11 +189,11 @@ iteraror.next().value
 Returns an iterator over the set's values.
 
 ```js
-var map = new SparseMap(4);
+const map = new SparseMap(4);
 
 map.set(2, 15);
 
-var iterator = map.values();
+const iterator = map.values();
 
 iteraror.next().value
 >>> 15
@@ -203,11 +204,11 @@ iteraror.next().value
 Returns an iterator over the set's entries.
 
 ```js
-var map = new SparseMap(4);
+const map = new SparseMap(4);
 
 map.set(2, 15);
 
-var iterator = map.entries();
+const iterator = map.entries();
 
 iteraror.next().value
 >>> [2, 15]
@@ -218,9 +219,9 @@ iteraror.next().value
 Alternatively, you can iterate over a map's entries using ES2015 `for...of` protocol:
 
 ```js
-var map = new SparseMap(4);
+const map = new SparseMap(4);
 
-for (var [key, value] of map) {
+for (const [key, value] of map) {
   console.log(key, value);
 }
 ```

--- a/sparse-queue-set.md
+++ b/sparse-queue-set.md
@@ -8,13 +8,13 @@ A `SparseQueueSet` is a very time-efficient set structure used to store a range 
 The `SparseQueueSet` is to be used as a queue where elements cannot exist more than once.
 
 ```js
-var SparseQueueSet = require('mnemonist/sparse-queue-set');
+const SparseQueueSet = require('mnemonist/sparse-queue-set');
 ```
 
 ## Constructor
 
 ```js
-var queue = new SparseQueueSet(length);
+const queue = new SparseQueueSet(length);
 ```
 
 ## Members
@@ -45,7 +45,7 @@ var queue = new SparseQueueSet(length);
 Capacity of the set, that is to say the maximum number one can expect to store in this set minus one.
 
 ```js
-var queue = new SparseQueueSet(4);
+const queue = new SparseQueueSet(4);
 
 queue.capacity;
 >>> 4
@@ -56,7 +56,7 @@ queue.capacity;
 Number of items currently in the queue.
 
 ```js
-var queue = new SparseQueueSet(4);
+const queue = new SparseQueueSet(4);
 
 queue.size;
 >>> 0
@@ -74,7 +74,7 @@ Adds a number to the queue.
 `O(1)`
 
 ```js
-var queue = new SparseQueueSet(4);
+const queue = new SparseQueueSet(4);
 
 queue.enqueue(2);
 queue.has(2);
@@ -88,7 +88,7 @@ Removes and retrieves the first item stored in the queue or `undefined`.
 `O(1)`
 
 ```js
-var queue = new SparseQueueSet(4);
+const queue = new SparseQueueSet(4);
 
 queue.enqueue(2);
 queue.enqueue(0);
@@ -104,7 +104,7 @@ queue.has(2)
 Removes every number stored in the queue.
 
 ```js
-var queue = new SparseQueueSet(4);
+const queue = new SparseQueueSet(4);
 
 queue.enqueue(1);
 queue.enqueue(3);
@@ -121,7 +121,7 @@ Returns whether the given number exists in the queue.
 `O(1)`
 
 ```js
-var queue = new SparseQueueSet(4);
+const queue = new SparseQueueSet(4);
 
 queue.has(3);
 >>> false
@@ -137,7 +137,7 @@ queue.has(3);
 Iterates over the queue's numbers.
 
 ```js
-var queue = new SparseQueueSet(4);
+const queue = new SparseQueueSet(4);
 
 queue.enqueue(1);
 
@@ -151,11 +151,11 @@ queue.forEach(function(number) {
 Returns an iterator over the queue's number.
 
 ```js
-var queue = new SparseQueueSet(4);
+const queue = new SparseQueueSet(4);
 
 queue.enqueue(2);
 
-var iterator = queue.values()
+const iterator = queue.values()
 
 iteraror.next().value
 >>> 2
@@ -166,9 +166,9 @@ iteraror.next().value
 Alternatively, you can iterate over a queue's values using ES2015 `for...of` protocol:
 
 ```js
-var queue = new SparseQueueSet(4);
+const queue = new SparseQueueSet(4);
 
-for (var number of queue) {
+for (const number of queue) {
   console.log(number);
 }
 ```

--- a/sparse-queue-set.md
+++ b/sparse-queue-set.md
@@ -141,7 +141,7 @@ const queue = new SparseQueueSet(4);
 
 queue.enqueue(1);
 
-queue.forEach(function(number) {
+queue.forEach((number) => {
   console.log(number);
 });
 ```

--- a/sparse-set.md
+++ b/sparse-set.md
@@ -140,7 +140,7 @@ const set = new SparseSet(4);
 
 set.add(1);
 
-set.forEach(function(number) {
+set.forEach((number) => {
   console.log(number);
 });
 ```

--- a/sparse-set.md
+++ b/sparse-set.md
@@ -10,13 +10,13 @@ Contrary to the [`BitSet`]({{ site.baseurl }}/bit-set), the `SparseSet` is very 
 If you also need to associate values to the set's members, take a look to [`SparseMap`]({{ site.baseurl }}/sparse-map) instead.
 
 ```js
-var SparseSet = require('mnemonist/sparse-set');
+const SparseSet = require('mnemonist/sparse-set');
 ```
 
 ## Constructor
 
 ```js
-var set = new SparseSet(length);
+const set = new SparseSet(length);
 ```
 
 ## Members
@@ -47,7 +47,7 @@ var set = new SparseSet(length);
 Length of the set, that is to say the maximum number one can expect to store in this set minus one.
 
 ```js
-var set = new SparseSet(4);
+const set = new SparseSet(4);
 
 set.length;
 >>> 4
@@ -58,7 +58,7 @@ set.length;
 Number of items currently in the set.
 
 ```js
-var set = new SparseSet(4);
+const set = new SparseSet(4);
 
 set.size;
 >>> 0
@@ -76,7 +76,7 @@ Adds a number to the set.
 `O(1)`
 
 ```js
-var set = new SparseSet(4);
+const set = new SparseSet(4);
 
 set.add(2);
 set.has(2);
@@ -90,7 +90,7 @@ Deletes the given number from the set.
 `O(1)`
 
 ```js
-var set = new SparseSet(4);
+const set = new SparseSet(4);
 
 set.add(2);
 set.delete(2);
@@ -103,7 +103,7 @@ set.has(2);
 Resets every number stored by the set.
 
 ```js
-var set = new SparseSet(4);
+const set = new SparseSet(4);
 
 set.set(1);
 set.set(3);
@@ -120,7 +120,7 @@ Returns whether the given number exists in the set.
 `O(1)`
 
 ```js
-var set = new SparseSet(4);
+const set = new SparseSet(4);
 
 set.has(3);
 >>> false
@@ -136,7 +136,7 @@ set.has(3);
 Iterates over the set's numbers.
 
 ```js
-var set = new SparseSet(4);
+const set = new SparseSet(4);
 
 set.add(1);
 
@@ -150,11 +150,11 @@ set.forEach(function(number) {
 Returns an iterator over the set's number.
 
 ```js
-var set = new SparseSet(4);
+const set = new SparseSet(4);
 
 set.add(2);
 
-var iterator = set.values()
+const iterator = set.values()
 
 iteraror.next().value
 >>> 2
@@ -165,9 +165,9 @@ iteraror.next().value
 Alternatively, you can iterate over a set's values using ES2015 `for...of` protocol:
 
 ```js
-var set = new SparseSet(4);
+const set = new SparseSet(4);
 
-for (var number of set) {
+for (const number of set) {
   console.log(number);
 }
 ```

--- a/stack.md
+++ b/stack.md
@@ -27,7 +27,7 @@ while (stack.size) {
   const node = stack.pop();
   console.log('Traversed node:', node);
 
-  node.children.forEach(function(child) {
+  node.children.forEach((child) => {
     stack.push(child);
   });
 }
@@ -152,7 +152,7 @@ const stack = new Stack();
 stack.push(1);
 stack.push(2);
 
-stack.forEach(function(item, index, stack) {
+stack.forEach((item, index, stack) => {
   console.log(index, item);
 });
 ```

--- a/stack.md
+++ b/stack.md
@@ -12,7 +12,7 @@ For more information about the Stack, you can head [here](https://en.wikipedia.o
 Note that if you know the maximum size your stack will have and if you want a more performant stack implementation, you can check the [`FiniteStack`]({{ site.baseurl }}/finite-stack).
 
 ```js
-var Stack = require('mnemonist/stack');
+const Stack = require('mnemonist/stack');
 ```
 
 ## Use case
@@ -20,11 +20,11 @@ var Stack = require('mnemonist/stack');
 A stack is really useful to perform, for instance, the depth-first traversal of a tree:
 
 ```js
-var stack = new Stack();
+const stack = new Stack();
 stack.push(tree.root);
 
 while (stack.size) {
-  var node = stack.pop();
+  const node = stack.pop();
   console.log('Traversed node:', node);
 
   node.children.forEach(function(child) {
@@ -42,7 +42,7 @@ The `Stack` takes no argument.
 Alternatively, one can build a `Stack` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var stack = Stack.from([1, 2, 3]);
+const stack = Stack.from([1, 2, 3]);
 ```
 
 ### Static #.of
@@ -50,7 +50,7 @@ var stack = Stack.from([1, 2, 3]);
 You can also build a `Stack` from an arbitrary set of arguments:
 
 ```js
-var stack = Stack.of(1, 2, 3);
+const stack = Stack.of(1, 2, 3);
 ```
 
 ## Members
@@ -82,7 +82,7 @@ var stack = Stack.of(1, 2, 3);
 Number of items in the stack.
 
 ```js
-var stack = new Stack();
+const stack = new Stack();
 stack.size
 >>> 0
 ```
@@ -94,7 +94,7 @@ Adds an item to the stack.
 `O(1)`
 
 ```js
-var stack = new Stack();
+const stack = new Stack();
 
 stack.push(1);
 ```
@@ -106,7 +106,7 @@ Retrieve & remove the next item of the stack.
 `O(1)`
 
 ```js
-var stack = new Stack();
+const stack = new Stack();
 
 stack.push(1);
 stack.pop();
@@ -120,7 +120,7 @@ Completely clears the stack.
 `O(1)`
 
 ```js
-var stack = new Stack();
+const stack = new Stack();
 
 stack.push(1);
 stack.clear();
@@ -135,7 +135,7 @@ Retrieves the next item of the stack.
 `O(1)`
 
 ```js
-var stack = new Stack();
+const stack = new Stack();
 
 stack.push(1);
 stack.peek();
@@ -147,7 +147,7 @@ stack.peek();
 Iterates over the stack in LIFO order.
 
 ```js
-var stack = new Stack();
+const stack = new Stack();
 
 stack.push(1);
 stack.push(2);
@@ -162,7 +162,7 @@ stack.forEach(function(item, index, stack) {
 Converts the stack into a LIFO JavaScript array.
 
 ```js
-var stack = new Stack();
+const stack = new Stack();
 
 stack.push(1);
 stack.push(2);
@@ -176,9 +176,9 @@ stack.toArray();
 Returns an iterator over the stack's values.
 
 ```js
-var stack = Stack.from([1, 2, 3]);
+const stack = Stack.from([1, 2, 3]);
 
-var iterator = stack.values();
+const iterator = stack.values();
 
 iterator.next().value
 >>> 3
@@ -189,9 +189,9 @@ iterator.next().value
 Returns an iterator over the stack's entries.
 
 ```js
-var stack = Stack.from([1, 2, 3]);
+const stack = Stack.from([1, 2, 3]);
 
-var iterator = stack.entries();
+const iterator = stack.entries();
 
 iterator.next().value
 >>> [0, 3]
@@ -202,9 +202,9 @@ iterator.next().value
 Alternatively, you can iterate over a stack's values using ES2015 `for...of` protocol:
 
 ```js
-var stack = Stack.from([1, 2, 3]);
+const stack = Stack.from([1, 2, 3]);
 
-for (var item of stack) {
+for (const item of stack) {
   console.log(item);
 }
 ```

--- a/static-disjoint-set.md
+++ b/static-disjoint-set.md
@@ -11,7 +11,7 @@ It is however a very memory-efficient way to solve some issues such as finding c
 
 
 ```js
-var StaticDisjointSet = require('mnemonist/static-disjoint-set');
+const StaticDisjointSet = require('mnemonist/static-disjoint-set');
 ```
 
 ## Constructor
@@ -19,7 +19,7 @@ var StaticDisjointSet = require('mnemonist/static-disjoint-set');
 The `StaticDisjointSet` takes an initial size at instantiation time (i.e. the total number of items we are going to handle, the number of nodes in your graph, for instance).
 
 ```js
-var sets = new StaticDisjointSet(size);
+const sets = new StaticDisjointSet(size);
 ```
 
 ## Members
@@ -44,7 +44,7 @@ var sets = new StaticDisjointSet(size);
 Total number of sets known by the disjoint set (obviously less than or equal to the size).
 
 ```js
-var sets = new StaticDisjointSet(4);
+const sets = new StaticDisjointSet(4);
 
 sets.union(1, 2);
 sets.union(1, 3);
@@ -60,7 +60,7 @@ set.dimension;
 Total number of stored items.
 
 ```js
-var sets = new StaticDisjointSet(4);
+const sets = new StaticDisjointSet(4);
 
 set.size;
 >>> 4
@@ -73,7 +73,7 @@ set.size;
 Perform the union of two items. If they belong to different sets, their respective sets will be merged into a single one.
 
 ```js
-var sets = new StaticDisjointSet(4);
+const sets = new StaticDisjointSet(4);
 
 sets.union(1, 2);
 sets.union(1, 3);
@@ -86,7 +86,7 @@ sets.union(1, 3);
 Compile the disjoint sets into an array of arrays.
 
 ```js
-var sets = new StaticDisjointSet(4);
+const sets = new StaticDisjointSet(4);
 
 sets.union(1, 2);
 sets.union(1, 3);
@@ -103,7 +103,7 @@ sets.compile();
 Returns the root item of the given item's current set.
 
 ```js
-var sets = new StaticDisjointSet(4);
+const sets = new StaticDisjointSet(4);
 
 sets.union(1, 2);
 sets.union(1, 3);
@@ -119,7 +119,7 @@ sets.find(2);
 Returns an array whose values are the id of the item's set.
 
 ```js
-var sets = new StaticDisjointSet(4);
+const sets = new StaticDisjointSet(4);
 
 sets.union(1, 2);
 sets.union(1, 3);

--- a/static-interval-tree.md
+++ b/static-interval-tree.md
@@ -37,9 +37,7 @@ const figures = [
 ];
 
 // Searching for figures living in 1456
-figures.filter(function(figure) {
-  return figure.death >= 1456 && figure.birth <= 1456;
-});
+figures.filter((figure) => figure.death >= 1456 && figure.birth <= 1456);
 >>> [
  {name: 'John II of Cyprus', birth: 1418, death: 1458},
  {name: 'Helena Palaiologina', birth: 1428, death: 1458},

--- a/static-interval-tree.md
+++ b/static-interval-tree.md
@@ -19,7 +19,7 @@ Under the hood, this structure is implemented as an augmented binary search tree
 **Important note n°3**: for optimization reasons, this implementation currently only handles numbers. You can go around this limitation by converting your points to number through getters (dates can easily be converted to timestamps, for instance).
 
 ```js
-var StaticIntervalTree = require('mnemonist/static-interval-tree');
+const StaticIntervalTree = require('mnemonist/static-interval-tree');
 ```
 
 ## Use case
@@ -29,7 +29,7 @@ Let's say we have a large database of historical figures and we want to be able 
 The naive way would be to iterate over all our figures to find suitable ones.
 
 ```js
-var figures = [
+const figures = [
  {name: 'John II of Cyprus', birth: 1418, death: 1458},
  {name: 'Helena Palaiologina', birth: 1428, death: 1458},
  {name: 'Ashikaga Yoshikatsu', birth: 1434, death: 1443},
@@ -52,7 +52,7 @@ This is where the `StaticIntervalTree` can help you.
 
 ```js
 // Building our tree, using custom getters for start & end of intervals
-var tree = StaticIntervalTree.from(figures, [
+const tree = StaticIntervalTree.from(figures, [
   f => f.birth,
   f => f.death
 ]);
@@ -76,16 +76,16 @@ You can build a `StaticIntervalTree` from an arbitrary iterable.
 Alternatively, you can provide some customized start and end getters if you want to represent your intervals differently than an array.
 
 ```js
-var tree = StaticIntervalTree.from([[0, 1], [20, 34]]);
+const tree = StaticIntervalTree.from([[0, 1], [20, 34]]);
 
 // Using specialized getters
-var figures = [
+const figures = [
  {name: 'John II of Cyprus', birth: 1418, death: 1458},
  {name: 'Helena Palaiologina', birth: 1428, death: 1458},
  {name: 'Ashikaga Yoshikatsu', birth: 1434, death: 1443}
 ];
 
-var tree = StaticIntervalTree.from(figures, [
+const tree = StaticIntervalTree.from(figures, [
   f => f.birth,
   f => f.death
 ]);
@@ -110,7 +110,7 @@ The tree is built in `O(n log n)` time.
 Height of the underlying binary search tree.
 
 ```js
-var tree = StaticIntervalTree.from([[0, 1], [20, 34]]);
+const tree = StaticIntervalTree.from([[0, 1], [20, 34]]);
 
 tree.height
 >>> 3
@@ -121,7 +121,7 @@ tree.height
 Number of stored intervals.
 
 ```js
-var tree = StaticIntervalTree.from([[0, 1], [20, 34]]);
+const tree = StaticIntervalTree.from([[0, 1], [20, 34]]);
 
 tree.size
 >>> 2
@@ -132,7 +132,7 @@ tree.size
 Retrieves an array of intervals containing the given point.
 
 ```js
-var tree = StaticIntervalTree.from([[0, 1], [20, 34]]);
+const tree = StaticIntervalTree.from([[0, 1], [20, 34]]);
 
 tree.intervalsContainingPoint(1);
 >>> [[0, 1]]
@@ -143,7 +143,7 @@ tree.intervalsContainingPoint(1);
 Retrieves an array of intervals overlapping with the given interval.
 
 ```js
-var tree = StaticIntervalTree.from([[0, 1], [20, 34]]);
+const tree = StaticIntervalTree.from([[0, 1], [20, 34]]);
 
 tree.intervalsOverlappingInterval([5, 24]);
 >>> [[20, 34]]

--- a/suffix-array.md
+++ b/suffix-array.md
@@ -38,7 +38,7 @@ But the real purpose of mnemonist's `SuffixArray` class is that it uses *Karkkai
 For more information about the Suffix Array, you can head [here](https://en.wikipedia.org/wiki/Suffix_array).
 
 ```js
-var SuffixArray = require('mnemonist/suffix-array');
+const SuffixArray = require('mnemonist/suffix-array');
 ```
 
 ## Constructor
@@ -46,10 +46,11 @@ var SuffixArray = require('mnemonist/suffix-array');
 The `SuffixArray` class simply takes a single string or arbitrary array of string tokens as its only argument:
 
 ```js
-var suffixArray = new SuffixArray('banana');
-
+const suffixArray = new SuffixArray('banana');
+```
+```js
 // Also works with arbitrary sequences of tokens
-var suffixArray = new SuffixArray(['the', 'cat', 'eats', 'the', 'mouse']);
+const suffixArray = new SuffixArray(['the', 'cat', 'eats', 'the', 'mouse']);
 ```
 
 Note that if you pass an arbitrary array of tokens, computation time for the suffix array is approximately `O(n log n)`, which is obviously slower than for a simple string.
@@ -65,7 +66,7 @@ Note that if you pass an arbitrary array of tokens, computation time for the suf
 The computed suffix array.
 
 ```js
-var suffixArray = new SuffixArray('banana');
+const suffixArray = new SuffixArray('banana');
 suffixArray.array
 >>> [5, 3, 1, 0, 4, 2]
 ```
@@ -75,7 +76,7 @@ suffixArray.array
 The length of the array.
 
 ```js
-var suffixArray = new SuffixArray('banana');
+const suffixArray = new SuffixArray('banana');
 suffixArray.length
 >>> 6
 ```
@@ -85,7 +86,7 @@ suffixArray.length
 The stored string.
 
 ```js
-var suffixArray = new SuffixArray('banana');
+const suffixArray = new SuffixArray('banana');
 suffixArray.string
 >>> 'banana'
 ```

--- a/symspell.md
+++ b/symspell.md
@@ -12,7 +12,7 @@ However, it really shines when you want the max edit distance between your queri
 For more information, you can head toward [this](http://blog.faroo.com/2015/03/24/fast-approximate-string-matching-with-large-edit-distances/) seminal blog post.
 
 ```js
-var SymSpell = require('mnemonist/symspell');
+const SymSpell = require('mnemonist/symspell');
 ```
 
 ## Use case
@@ -24,7 +24,7 @@ When the user inputs a string, we are going to search for every term we know bei
 The naive method would be to "brute-force" the list of terms likewise:
 
 ```js
-var suggestions = terms.filter(term => {
+const suggestions = terms.filter(term => {
   return levenshtein(term, query) <= 2;
 });
 ```
@@ -34,10 +34,10 @@ But, even if this works with few terms, it will soon become hard to compute if t
 SymSpell indexes solves this problem by indexing the list of terms such as it becomes efficient to query them in a fuzzy way.
 
 ```js
-var index = SymSpell.from(terms);
+const index = SymSpell.from(terms);
 
 // We can now query the index easily:
-var suggestions = index.search(query);
+const suggestions = index.search(query);
 ```
 
 ## Constructor
@@ -45,13 +45,13 @@ var suggestions = index.search(query);
 The `SymSpell` takes a single optional argument being some options.
 
 ```js
-var index = new SymSpell(options);
+const index = new SymSpell(options);
 ```
 
 *Example with a higher max distance*
 
 ```js
-var index = new SymSpell({
+const index = new SymSpell({
   maxDistance: 3
 });
 ```
@@ -69,7 +69,7 @@ var index = new SymSpell({
 Alternatively, one can build a `SymSpell` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var index = SymSpell.from(['hello', 'mello'], options);
+const index = SymSpell.from(['hello', 'mello'], options);
 ```
 
 ## Members
@@ -92,7 +92,7 @@ var index = SymSpell.from(['hello', 'mello'], options);
 Total number of items stored in the index.
 
 ```js
-var index = new SymSpell();
+const index = new SymSpell();
 
 index.add('hello');
 
@@ -105,7 +105,7 @@ index.size
 Adds a single item to the index.
 
 ```js
-var index = new SymSpell();
+const index = new SymSpell();
 
 index.add('hello');
 ```
@@ -115,7 +115,7 @@ index.add('hello');
 Completely clears the index of its items.
 
 ```js
-var index = new SymSpell();
+const index = new SymSpell();
 
 index.add('hello');
 index.clear();
@@ -129,7 +129,7 @@ index.size
 Returns every item relevant to the given query.
 
 ```js
-var index = new SymSpell();
+const index = new SymSpell();
 
 index.add('hello');
 index.add('mello');

--- a/trie-map.md
+++ b/trie-map.md
@@ -6,7 +6,7 @@ title: TrieMap
 The `TrieMap` is basically a [`Trie`]({{ site.baseurl }}/trie) in which you can associate an arbitraty value to the prefixes you insert.
 
 ```js
-var TrieMap = require('mnemonist/trie-map');
+const TrieMap = require('mnemonist/trie-map');
 ```
 
 ## Constructor
@@ -15,10 +15,11 @@ The `TrieMap` optionally takes as single argument the type of sequence you are g
 
 ```js
 // For a trie containing string prefixes
-var trie = new TrieMap();
-
+const trie = new TrieMap();
+```
+```js
 // For a trie containing arbitrary sequences fed as arrays
-var trie = new TrieMap(Array);
+const trie = new TrieMap(Array);
 ```
 
 ### Static #.from
@@ -26,7 +27,7 @@ var trie = new TrieMap(Array);
 Alternatively, one can build a `TrieMap` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var list = TrieMap.from({
+const list = TrieMap.from({
   roman: 1,
   romanesque: 2
 });
@@ -64,7 +65,7 @@ var list = TrieMap.from({
 Number of prefixes in the trie.
 
 ```js
-var trie = new TrieMap();
+const trie = new TrieMap();
 trie.size
 >>> 0
 ```
@@ -76,7 +77,7 @@ Inserts a prefix into the Trie and associates it to the given value.
 `O(m)`, m being the size of the inserted string.
 
 ```js
-var trie = new TrieMap();
+const trie = new TrieMap();
 trie.set('hello', 'world');
 
 trie.get('hello');
@@ -93,9 +94,9 @@ Updates the value associated with a prefix. Accepts a function receiving the cur
 `O(m)`, m being the size of the prefix string.
 
 ```js
-var trie = new TrieMap();
+const trie = new TrieMap();
 
-var updater = v => (v || 0) + 1;
+const updater = v => (v || 0) + 1;
 
 trie.update('counter', updater);
 trie.update('counter', updater);
@@ -111,7 +112,7 @@ Deletes a prefix from the TrieMap. Returns `true` if the prefix was deleted & `f
 `O(m)`, m being the size of the deleted string.
 
 ```js
-var trie = new TrieMap();
+const trie = new TrieMap();
 trie.add('hello');
 
 trie.delete('hello');
@@ -126,7 +127,7 @@ trie.delete('world');
 Completely clears the trie.
 
 ```js
-var trie = new TrieMap();
+const trie = new TrieMap();
 trie.set('hello', 1);
 trie.set('roman', 2);
 
@@ -143,7 +144,7 @@ Returns the value associated to the given prefix or `undefined` if the prefix do
 `O(m)`, m being the size of the searched string.
 
 ```js
-var trie = new TrieMap();
+const trie = new TrieMap();
 trie.set('hello', 'world');
 
 trie.get('hello');
@@ -157,7 +158,7 @@ Returns whether the given prefix exists in the trie.
 `O(m)`, m being the size of the searched string.
 
 ```js
-var trie = new TrieMap();
+const trie = new TrieMap();
 trie.set('hello', 'world');
 
 trie.has('hello');
@@ -174,7 +175,7 @@ Returns an array of couples of every prefixes and their associated value found i
 `O(m + n)`, m being the size of the query, n being the cumulated size of the matched prefixes.
 
 ```js
-var trie = new TrieMap();
+const trie = new TrieMap();
 trie.set('roman', 1);
 trie.set('romanesque', 2);
 trie.set('greek', 3);
@@ -194,9 +195,9 @@ trie.find('hel');
 Returns an iterator over the trie's entries (note that the order on which the trie will iterate over its entries is arbitrary).
 
 ```js
-var trie = TrieMap.from({roman: 1, romanesque: 2});
+const trie = TrieMap.from({roman: 1, romanesque: 2});
 
-var iterator = trie.entries();
+const iterator = trie.entries();
 
 iterator.next().value
 >>> ['roman', 1]
@@ -211,9 +212,9 @@ Alias of [#.prefixes](#prefixes).
 Returns an iterator over the trie's prefixes (note that the order on which the trie will iterate over its prefixes is arbitrary).
 
 ```js
-var trie = TrieMap.from({roman: 1, romanesque: 2});
+const trie = TrieMap.from({roman: 1, romanesque: 2});
 
-var iterator = trie.prefixes();
+const iterator = trie.prefixes();
 
 iterator.next().value
 >>> 'roman'
@@ -224,9 +225,9 @@ iterator.next().value
 Returns an iterator over the trie's values (note that the order on which the trie will iterate over its values is arbitrary).
 
 ```js
-var trie = TrieMap.from({roman: 1, romanesque: 2});
+const trie = TrieMap.from({roman: 1, romanesque: 2});
 
-var iterator = trie.values();
+const iterator = trie.values();
 
 iterator.next().value
 >>> 1
@@ -237,9 +238,9 @@ iterator.next().value
 Alternatively, you can iterate over a trie's entries using ES2015 `for...of` protocol:
 
 ```js
-var trie = TrieMap.from({roman: 1, romanesque: 2});
+const trie = TrieMap.from({roman: 1, romanesque: 2});
 
-for (var entry of trie) {
+for (const entry of trie) {
   console.log(entry);
 }
 ```

--- a/trie.md
+++ b/trie.md
@@ -8,7 +8,7 @@ The trie - pronounced like in *re•trie•val* - is a kind tree very useful to 
 For more information about the Trie, you can head [here](https://en.wikipedia.org/wiki/Trie).
 
 ```js
-var Trie = require('mnemonist/trie');
+const Trie = require('mnemonist/trie');
 ```
 
 ## Use case
@@ -16,7 +16,7 @@ var Trie = require('mnemonist/trie');
 Let's say we have a list of strings and we want to be able to find them by a given prefix:
 
 ```js
-var words = [
+const words = [
   'roman',
   'romanesque',
   'romanesco',
@@ -40,10 +40,10 @@ A trie, on the contrary, is able to answer this kind of query more efficiently:
 
 ```js
 // Let's create a trie from our words
-var trie = Trie.from(words);
+const trie = Trie.from(words);
 
 // Now let's query our trie
-var wordsWithMatchingPrefix = trie.find(query);
+const wordsWithMatchingPrefix = trie.find(query);
 ```
 
 ## Constructor
@@ -52,10 +52,11 @@ The `Trie` optionally takes as single argument the type of sequence you are goin
 
 ```
 // For a trie containing string prefixes
-var trie = new Trie();
-
+const trie = new Trie();
+```
+```js
 // For a trie containing arbitrary sequences fed as arrays
-var trie = new Trie(Array);
+const trie = new Trie(Array);
 ```
 
 ### Static #.from
@@ -63,7 +64,7 @@ var trie = new Trie(Array);
 Alternatively, one can build a `Trie` from an arbitrary JavaScript iterable likewise:
 
 ```js
-var list = Trie.from(['roman', 'romanesque']);
+const list = Trie.from(['roman', 'romanesque']);
 ```
 
 ## Members
@@ -94,7 +95,7 @@ var list = Trie.from(['roman', 'romanesque']);
 Number of prefixes in the trie.
 
 ```js
-var trie = new Trie();
+const trie = new Trie();
 trie.size
 >>> 0
 ```
@@ -106,7 +107,7 @@ Adds a prefix into the Trie. If the prefix is a string, it will be split into ch
 `O(m)`, m being the size of the inserted string.
 
 ```js
-var trie = new Trie();
+const trie = new Trie();
 trie.add('hello');
 
 trie.has('hello');
@@ -123,7 +124,7 @@ Deletes a prefix from the Trie. Returns `true` if the prefix was deleted & `fals
 `O(m)`, m being the size of the deleted string.
 
 ```js
-var trie = new Trie();
+const trie = new Trie();
 trie.add('hello');
 
 trie.delete('hello');
@@ -138,7 +139,7 @@ trie.delete('world');
 Completely clears the trie.
 
 ```js
-var trie = new Trie();
+const trie = new Trie();
 trie.add('hello');
 trie.add('roman');
 
@@ -155,7 +156,7 @@ Returns whether the given prefix exists in the trie.
 `O(m)`, m being the size of the searched string.
 
 ```js
-var trie = new Trie();
+const trie = new Trie();
 trie.add('hello');
 
 trie.has('hello');
@@ -172,7 +173,7 @@ Returns an array of every prefixes found in the trie with the given prefix.
 `O(m + n)`, m being the size of the query, n being the cumulated size of the matched prefixes.
 
 ```js
-var trie = new Trie();
+const trie = new Trie();
 trie.add('roman');
 trie.add('romanesque');
 trie.add('greek');
@@ -196,9 +197,9 @@ Alias of [#.prefixes](#prefixes).
 Returns an iterator over the trie's prefixes (note that the order on which the trie will iterate over its prefixes is arbitrary).
 
 ```js
-var trie = Trie.from(['roman', 'romanesque']);
+const trie = Trie.from(['roman', 'romanesque']);
 
-var iterator = trie.prefixes();
+const iterator = trie.prefixes();
 
 iterator.next().value
 >>> 'roman'
@@ -209,9 +210,9 @@ iterator.next().value
 Alternatively, you can iterate over a trie's prefixes using ES2015 `for...of` protocol:
 
 ```js
-var trie = Trie.from(['roman', 'romanesque']);
+const trie = Trie.from(['roman', 'romanesque']);
 
-for (var prefix of trie) {
+for (const prefix of trie) {
   console.log(prefix);
 }
 ```

--- a/trie.md
+++ b/trie.md
@@ -28,7 +28,7 @@ const words = [
 A naive approach would be to compare each of our strings with the given prefix to find the matching ones:
 
 ```js
-words.forEach(function(word) {
+words.forEach((word) => {
   if (word.startsWith(query))
     console.log('Matching prefix!', word);
 });

--- a/vector.md
+++ b/vector.md
@@ -14,7 +14,7 @@ Also, dynamic arrays are faster than JavaScript's `Array` (else, all this would 
 Just keep in mind that even if a `Int8Vector` really is faster, a `Float64Vector` won't give you an edge because this is often how an `Array` containing number would be optimized under the hood by most JavaScript engines.
 
 ```js
-var Vector = require('mnemonist/vector');
+const Vector = require('mnemonist/vector');
 ```
 
 ## Constructor
@@ -22,27 +22,29 @@ var Vector = require('mnemonist/vector');
 The `Vector` takes a typed array class as first argument and an initial capacity or alternatively more complex options as second argument.
 
 ```js
-var vector = new Vector(ArrayClass, initialCapacity);
-
+const vector = new Vector(ArrayClass, initialCapacity);
+```
+```js
 // If you need to pass options such as a custom growth policy
-var vector = new Vector(ArrayClass, {
+const vector = new Vector(ArrayClass, {
   initialCapacity: 10,
   initialLength: 3,
   policy: function(capacity) {
     return Math.ceil(capacity * 2.5);
   }
 });
-
-// Subclasses for each of JS typed array also exists as a convenience
-var vector = new Vector.Int8Vector(initialCapacity);
-var vector = new Vector.Uint8Vector(initialCapacity);
-var vector = new Vector.Uint8Vector(initialCapacity);
-var vector = new Vector.Int16Vector(initialCapacity);
-var vector = new Vector.Uint16Vector(initialCapacity);
-var vector = new Vector.Int32Vector(initialCapacity);
-var vector = new Vector.Uint32Vector(initialCapacity);
-var vector = new Vector.Float32Vector(initialCapacity);
-var vector = new Vector.Float64Vector(initialCapacity);
+```
+Subclasses for each of JS typed array also exists as a convenience.
+```js
+vector = new Vector.Int8Vector(initialCapacity);
+vector = new Vector.Uint8Vector(initialCapacity);
+vector = new Vector.Uint8Vector(initialCapacity);
+vector = new Vector.Int16Vector(initialCapacity);
+vector = new Vector.Uint16Vector(initialCapacity);
+vector = new Vector.Int32Vector(initialCapacity);
+vector = new Vector.Uint32Vector(initialCapacity);
+vector = new Vector.Float32Vector(initialCapacity);
+vector = new Vector.Float64Vector(initialCapacity);
 ```
 
 ### Static #.from
@@ -51,13 +53,15 @@ Alternatively, one can build a `Vector` from an arbitrary JavaScript iterable li
 
 ```js
 // Attempting the guess the given iterable's length/size
-var vector = Vector.from([1, 2, 3], Int8Array);
-
+const vector = Vector.from([1, 2, 3], Int8Array);
+```
+```js
 // Providing the desired capacity
-var vector = Vector.from([1, 2, 3], Int8Array, 10);
-
+const vector = Vector.from([1, 2, 3], Int8Array, 10);
+```
+```js
 // Subclasses also have a static #.from
-var vector = Vector.Uint16Vector.from([1, 2, 3]);
+const vector = Vector.Uint16Vector.from([1, 2, 3]);
 ```
 
 ## Members
@@ -93,7 +97,7 @@ var vector = Vector.Uint16Vector.from([1, 2, 3]);
 The underlying typed array, if you need it for any reason (probably performance, in some precise use cases).
 
 ```js
-var vector = new Vector(Uint8Array, 4);
+const vector = new Vector(Uint8Array, 4);
 
 vector.push(1);
 vector.push(2);
@@ -103,7 +107,7 @@ vector.array
 
 // BEWARE: don't keep a reference of this array
 // it can be swapped by the implementation when growing!
-var underlyingArray = vector.array;
+const underlyingArray = vector.array;
 // ^ this could result in unexpected behaviors
 // if you expand the array later on
 // Example:
@@ -122,7 +126,7 @@ vector.array
 Real length of the underlying array, i.e. the maximum number of items the array can hold before needing to resize. Not to be confused with [#.length](#length).
 
 ```js
-var vector = new Vector(Uint8Array, 10);
+const vector = new Vector(Uint8Array, 10);
 
 vector.push(1);
 vector.push(2);
@@ -136,7 +140,7 @@ vector.capacity
 Current length of the vector, that is to say the last set index plus one.
 
 ```js
-var vector = new Vector(Uint8Array, 10);
+const vector = new Vector(Uint8Array, 10);
 
 vector.push(1);
 vector.push(2);
@@ -152,7 +156,7 @@ Applies the growing policy once and reallocates the underlying array.
 If given a number, will run the growing policy until we attain a suitable capacity.
 
 ```js
-var vector = new Vector(Uint8Array, 3);
+const vector = new Vector(Uint8Array, 3);
 
 vector.grow();
 
@@ -165,7 +169,7 @@ vector.grow(100);
 Sets the value at the given index.
 
 ```js
-var vector = new Vector(Uint8Array, 2);
+const vector = new Vector(Uint8Array, 2);
 
 vector.set(1, 45);
 
@@ -178,7 +182,7 @@ vector.get(1);
 Removes & returns the last value of the vector.
 
 ```js
-var vector = new Vector(Uint8Array, 2);
+const vector = new Vector(Uint8Array, 2);
 
 vector.push(1);
 vector.push(2);
@@ -195,7 +199,7 @@ vector.length
 Pushes a new value in the vector.
 
 ```js
-var vector = new Vector(Uint8Array, 2);
+const vector = new Vector(Uint8Array, 2);
 
 vector.push(1);
 vector.push(2);
@@ -214,7 +218,7 @@ vector.get(1);
 Reallocates the underlying array and truncates length if needed.
 
 ```js
-var vector = new Vector(Uint8Array, 3);
+const vector = new Vector(Uint8Array, 3);
 
 vector.reallocate(10);
 
@@ -231,7 +235,7 @@ Resize the vector's length. Will reallocate if current capacity is insufficient.
 Note that it won't deallocate if the given length is inferior to the current one. You can use [#.reallocate](#reallocate) for that.
 
 ```js
-var vector = new Vector(Uint8Array, {initialLength: 10});
+const vector = new Vector(Uint8Array, {initialLength: 10});
 
 vector.resize(5);
 vector.length;
@@ -252,7 +256,7 @@ vector.capacity;
 Retrieves the value stored at the given index.
 
 ```js
-var vector = new Vector(Uint8Array, 2);
+const vector = new Vector(Uint8Array, 2);
 
 vector.push(1);
 vector.push(2);
@@ -268,7 +272,7 @@ vector.get(1);
 Iterates over the vector's items.
 
 ```js
-var vector = new Vector(Array, 10);
+const vector = new Vector(Array, 10);
 
 stack.push(1);
 stack.push(2);
@@ -283,9 +287,9 @@ stack.forEach(function(item, index, stack) {
 Returns an iterator over the vector's values.
 
 ```js
-var vector = Vector.from([1, 2, 3], Uint8Array);
+const vector = Vector.from([1, 2, 3], Uint8Array);
 
-var iterator = vector.values();
+const iterator = vector.values();
 
 iterator.next().value
 >>> 3
@@ -296,9 +300,9 @@ iterator.next().value
 Returns an iterator over the vector's entries.
 
 ```js
-var vector = Vector.from([1, 2, 3], Uint8Array);
+const vector = Vector.from([1, 2, 3], Uint8Array);
 
-var iterator = vector.entries();
+const iterator = vector.entries();
 
 iterator.next().value
 >>> [0, 3]
@@ -309,9 +313,9 @@ iterator.next().value
 Alternatively, you can iterate over a vector's values using ES2015 `for...of` protocol:
 
 ```js
-var vector = Vector.from([1, 2, 3], Uint8Array);
+const vector = Vector.from([1, 2, 3], Uint8Array);
 
-for (var item of vector) {
+for (const item of vector) {
   console.log(item);
 }
 ```

--- a/vector.md
+++ b/vector.md
@@ -29,9 +29,7 @@ const vector = new Vector(ArrayClass, initialCapacity);
 const vector = new Vector(ArrayClass, {
   initialCapacity: 10,
   initialLength: 3,
-  policy: function(capacity) {
-    return Math.ceil(capacity * 2.5);
-  }
+  policy: (capacity) => Math.ceil(capacity * 2.5)  
 });
 ```
 Subclasses for each of JS typed array also exists as a convenience.
@@ -277,7 +275,7 @@ const vector = new Vector(Array, 10);
 stack.push(1);
 stack.push(2);
 
-stack.forEach(function(item, index, stack) {
+stack.forEach((item, index, stack) => {
   console.log(index, item);
 });
 ```

--- a/vp-tree.md
+++ b/vp-tree.md
@@ -12,7 +12,7 @@ However, one should keep in mind that a `VPTree` has worst cases - mostly due to
 For more information about the `VPTree`, you can head [here](https://en.wikipedia.org/wiki/Vantage-point_tree).
 
 ```js
-var VPTree = require('mnemonist/vp-tree');
+const VPTree = require('mnemonist/vp-tree');
 ```
 
 ## Constructor
@@ -26,7 +26,7 @@ You need two things to be able to build a `VPTree`: a list of items to index and
 Note that the provided metric distance must be a [true metric](https://en.wikipedia.org/wiki/Metric_(mathematics)) else the tree cannot work properly.
 
 ```js
-var tree = VPTree.from(['hello', 'mello'], distance);
+const tree = VPTree.from(['hello', 'mello'], distance);
 ```
 
 The tree is built in `O(n log n)` time.
@@ -47,7 +47,7 @@ The tree is built in `O(n log n)` time.
 Total number of items stored in the tree.
 
 ```js
-var tree = new VPTree(distance, ['hello']);
+const tree = new VPTree(distance, ['hello']);
 
 tree.size
 >>> 1
@@ -60,7 +60,7 @@ Returns the k nearest neighbors of the given query. Note that the resulting arra
 `O(log n + m)`, m being the number of matches.
 
 ```js
-var words = [
+const words = [
   'book',
   'back',
   'bock',
@@ -70,7 +70,7 @@ var words = [
   'ephemeral'
 ];
 
-var tree = new VPTree(levenshtein, words);
+const tree = new VPTree(levenshtein, words);
 
 // Retrieving the 2 nearest neighbors of "look"
 tree.nearestNeighbors(2, 'look');
@@ -87,7 +87,7 @@ Return all the neighbors of the given query for the given radius. Note that the 
 `O(log n + m)`, m being the number of matches.
 
 ```js
-var words = [
+const words = [
   'book',
   'back',
   'bock',
@@ -97,7 +97,7 @@ var words = [
   'ephemeral'
 ];
 
-var tree = new VPTree(levenshtein, words);
+const tree = new VPTree(levenshtein, words);
 
 // Retrieving all the neighbors of "look" at a maximum distance of 2
 tree.neighbors(2, 'look');


### PR DESCRIPTION
The goal of this PR is to use common modern JavaScript syntax in the code examples of the documentation. 
This will increase the readability of the examples by being more familiar syntax. I should also help spread best practices with modern, as people tend to copy paste examples.

There are only two types of changes:
1. **Using `const` instead of `var`**
  I found no examples that need a `let`. Sometimes a code example declared the same variable multiple times, usually to explain overloads. In this case I splitted the example.
2. **Using arrow functions instead of anonymous functions**
  This mainly improves readability by reducing some noise. Formatting is by Prettier conventions.

While doing those changes I stumbled over two potential bugs, please review the commits
- https://github.com/Yomguithereal/mnemonist/commit/a6d02110229a8a8b843a1cf66b5e134350e7cbc0  syntax in `FuzzyMultiMap.from()` example was wrong, fixed to the best of my knowledge
-  https://github.com/Yomguithereal/mnemonist/commit/e0a35d27ac0acdf4fd0e7ab2f5e5d92e4d43bdd9 same problem as before in search-index but this file does not exist (maybe moved to inverted-index?)
