### PR TITLE
Fix Float64Vector mistakenly exported as Float64Array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 .eslintcache
 .DS_Store
 TODO.md
+.vscode

--- a/index.d.ts
+++ b/index.d.ts
@@ -44,5 +44,5 @@ export {default as SuffixArray, GeneralizedSuffixArray} from './suffix-array';
 export {default as SymSpell} from './symspell';
 export {default as Trie} from './trie';
 export {default as TrieMap} from './trie-map';
-export {default as Vector, Uint8Vector, Uint8ClampedVector, Int8Vector, Uint16Vector, Int16Vector, Uint32Vector, Int32Vector, Float32Vector, Float64Array} from './vector';
+export {default as Vector, Uint8Vector, Uint8ClampedVector, Int8Vector, Uint16Vector, Int16Vector, Uint32Vector, Int32Vector, Float32Vector, Float64Vector} from './vector';
 export {default as VPTree} from './vp-tree';

--- a/vector.d.ts
+++ b/vector.d.ts
@@ -2,7 +2,7 @@
  * Mnemonist Vector Typings
  * =========================
  */
-import {IArrayLikeConstructor} from './utils/types';
+import { IArrayLikeConstructor } from './utils/types';
 
 type VectorOptions = {
   initialLength?: number;
@@ -78,4 +78,4 @@ export class Uint16Vector extends TypedVector {}
 export class Int32Vector extends TypedVector {}
 export class Uint32Vector extends TypedVector {}
 export class Float32Vector extends TypedVector {}
-export class Float64Array extends TypedVector {}
+export class Float64Vector extends TypedVector {}


### PR DESCRIPTION
The TypeScript definition file for vector.js is now exporting `Float64Vector` instead of `Float64Array`.