### PR TITLE
Fix `BloomFilter.from` in type declaration

### DIFF
--- a/bloom-filter.d.ts
+++ b/bloom-filter.d.ts
@@ -25,5 +25,5 @@ export default class BloomFilter {
   toJSON(): Uint8Array;
 
   // Statics
-  from(iterable: Iterable<string>, options?: number | BloomFilterOptions): BloomFilter;
+  static from(iterable: Iterable<string>, options?: number | BloomFilterOptions): BloomFilter;
 }


### PR DESCRIPTION
`BloomFilter.from` was missing the `static` keyword.