### PR TITLE
Add sideEffects flag to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
       "require": "./*.js"
     }
   },
+  "sideEffects": false,
   "files": [
     "sort",
     "utils",


### PR DESCRIPTION
This allows packagers like webpack to optimize bundle size when a user is only using a few packages from mnemonist.

See https://webpack.js.org/guides/tree-shaking/ for webpack's docs.