### PR TITLE
Stop FixedDeque/CircularBuffer retaining items

### DIFF
--- a/circular-buffer.js
+++ b/circular-buffer.js
@@ -22,7 +22,7 @@ function CircularBuffer(ArrayClass, capacity) {
 
   this.ArrayClass = ArrayClass;
   this.capacity = capacity;
-  this.items = new ArrayClass(this.capacity);
+  // clear instantiates a new backing array
   this.clear();
 }
 

--- a/fixed-deque.js
+++ b/fixed-deque.js
@@ -22,7 +22,7 @@ function FixedDeque(ArrayClass, capacity) {
 
   this.ArrayClass = ArrayClass;
   this.capacity = capacity;
-  this.items = new ArrayClass(this.capacity);
+  // clear instantiates a new backing array
   this.clear();
 }
 
@@ -33,6 +33,8 @@ function FixedDeque(ArrayClass, capacity) {
  */
 FixedDeque.prototype.clear = function() {
 
+  // Re-create the backing array so anything stored in it can be GC'd
+  this.items = new this.ArrayClass(this.capacity);
   // Properties
   this.start = 0;
   this.size = 0;
@@ -95,7 +97,9 @@ FixedDeque.prototype.pop = function() {
   if (index >= this.capacity)
     index -= this.capacity;
 
-  return this.items[index];
+  var item = this.items[index];
+  this.items[index] = undefined;
+  return item;
 };
 
 /**
@@ -115,7 +119,9 @@ FixedDeque.prototype.shift = function() {
   if (this.start === this.capacity)
     this.start = 0;
 
-  return this.items[index];
+  var item = this.items[index];
+  this.items[index] = undefined;
+  return item;
 };
 
 /**

--- a/test/circular-buffer.js
+++ b/test/circular-buffer.js
@@ -336,4 +336,35 @@ describe('CircularBuffer', function() {
     assert.strictEqual(buffer.unshift(5), 4);
     assert.strictEqual(buffer.peekFirst(), 5);
   });
+
+  describe('should not retain items', function () {
+    var zero = { zero: 0 }, one = { one: 1 }, two = { two: 2 };
+
+    var buffer, uint8buffer;
+    beforeEach(function() {
+      buffer = CircularBuffer.from([zero, one, two], Array);
+      uint8buffer = CircularBuffer.from([0, 1, 2], Uint8Array);
+    });
+
+    it('on shift.', function() {
+      assert.strictEqual(buffer.shift(), zero);
+      assert.deepEqual(buffer.items, [undefined, one, two]);
+      assert.strictEqual(uint8buffer.shift(), 0);
+      assert.deepEqual(uint8buffer.items, Uint8Array.from([0, 1, 2]));
+    });
+
+    it('on pop.', function() {
+      assert.strictEqual(buffer.pop(), two);
+      assert.deepEqual(buffer.items, [zero, one, undefined]);
+      assert.strictEqual(uint8buffer.pop(), 2);
+      assert.deepEqual(uint8buffer.items, Uint8Array.from([0, 1, 0]));
+    });
+
+    it('on clear.', function() {
+      buffer.clear();
+      assert.deepEqual(buffer.items, new Array(3));
+      uint8buffer.clear();
+      assert.deepEqual(uint8buffer.items, Uint8Array.from([0, 0, 0]));
+    });
+  });
 });

--- a/test/fixed-deque.js
+++ b/test/fixed-deque.js
@@ -278,4 +278,35 @@ describe('FixedDeque', function() {
     assert.strictEqual(deque.unshift(5), 4);
     assert.strictEqual(deque.peekFirst(), 5);
   });
+
+  describe('should not retain items', function () {
+    var zero = { zero: 0 }, one = { one: 1 }, two = { two: 2 };
+
+    var deque, uint8deque;
+    beforeEach(function() {
+      deque = FixedDeque.from([zero, one, two], Array);
+      uint8deque = FixedDeque.from([0, 1, 2], Uint8Array);
+    });
+
+    it('on shift.', function() {
+      assert.strictEqual(deque.shift(), zero);
+      assert.deepEqual(deque.items, [undefined, one, two]);
+      assert.strictEqual(uint8deque.shift(), 0);
+      assert.deepEqual(uint8deque.items, Uint8Array.from([0, 1, 2]));
+    });
+
+    it('on pop.', function() {
+      assert.strictEqual(deque.pop(), two);
+      assert.deepEqual(deque.items, [zero, one, undefined]);
+      assert.strictEqual(uint8deque.pop(), 2);
+      assert.deepEqual(uint8deque.items, Uint8Array.from([0, 1, 0]));
+    });
+
+    it('on clear.', function() {
+      deque.clear();
+      assert.deepEqual(deque.items, new Array(3));
+      uint8deque.clear();
+      assert.deepEqual(uint8deque.items, Uint8Array.from([0, 0, 0]));
+    });
+  });
 });


### PR DESCRIPTION
on shift/pop/clear, preventing them from being GC'd.

Fixes #235

Just thrown this together quickly, let me know if you want the unit tests to be done differently at all.
